### PR TITLE
Include WebP in all image fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,8 @@ These are the fragments available on image assets, which allows easy lookup of t
 
 - `GatsbySanityImageFixed`
 - `GatsbySanityImageFixed_noBase64`
-- `GatsbySanityImageFixed_withWebp`
-- `GatsbySanityImageFixed_withWebp_noBase64`
 - `GatsbySanityImageFluid`
 - `GatsbySanityImageFluid_noBase64`
-- `GatsbySanityImageFluid_withWebp`
-- `GatsbySanityImageFluid_withWebp_noBase64`
 
 ## Overlaying drafts
 

--- a/fragments/imageFragments.js
+++ b/fragments/imageFragments.js
@@ -7,6 +7,8 @@ export const sanityImageFixed = graphql`
     height
     src
     srcSet
+    srcWebp
+    srcSetWebp
   }
 `
 
@@ -16,9 +18,13 @@ export const sanityImageFixedNoBase64 = graphql`
     height
     src
     srcSet
+    srcWebp
+    srcSetWebp
   }
 `
 
+// Not actually necessary - since Sanity CDN is scaling,
+// there is no "penalty" for including WebP by default
 export const sanityImageFixedPreferWebp = graphql`
   fragment GatsbySanityImageFixed_withWebp on SanityImageFixed {
     base64
@@ -31,6 +37,8 @@ export const sanityImageFixedPreferWebp = graphql`
   }
 `
 
+// Not actually necessary - since Sanity CDN is scaling,
+// there is no "penalty" for including WebP by default
 export const sanityImageFixedPreferWebpNoBase64 = graphql`
   fragment GatsbySanityImageFixed_withWebp_noBase64 on SanityImageFixed {
     width
@@ -48,6 +56,8 @@ export const sanityImageFluid = graphql`
     aspectRatio
     src
     srcSet
+    srcWebp
+    srcSetWebp
     sizes
   }
 `
@@ -57,10 +67,14 @@ export const sanityImageFluidNoBase64 = graphql`
     aspectRatio
     src
     srcSet
+    srcWebp
+    srcSetWebp
     sizes
   }
 `
 
+// Not actually necessary - since Sanity CDN is scaling,
+// there is no "penalty" for including WebP by default
 export const sanityImageFluidPreferWebp = graphql`
   fragment GatsbySanityImageFluid_withWebp on SanityImageFluid {
     base64
@@ -73,6 +87,8 @@ export const sanityImageFluidPreferWebp = graphql`
   }
 `
 
+// Not actually necessary - since Sanity CDN is scaling,
+// there is no "penalty" for including WebP by default
 export const SanityImageAssetFluidPreferWebpNoBase64 = graphql`
   fragment GatsbySanityImageFluid_withWebp_noBase64 on SanityImageFluid {
     aspectRatio


### PR DESCRIPTION
@KyleAMathews was kind enough to point out that there is no reason not to include the WebP versions  - they are optional in other plugins because they add to the build time, but since we let the Sanity CDN scale and transform our images, we can include them without any penalty. 

I've retained the fragments in code so as not to break people's build, but removed them from the readme - we should probably remove them in the next major release.