### PR TITLE
Add ability to materialize references within raw fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,20 @@ Remember to use the GraphiQL interface to help write the queries you need - it's
 
 Arrays and object types at the root of documents will get an additional "raw JSON" representation in a field called `_raw<FieldName>`. For instance, a field named `body` will be mapped to `_rawBody`. It's important to note that this is only done for top-level nodes (documents).
 
+Quite often, you'll want to replace reference fields (eg `_ref: '<documentId>'`, or `someField___NODE: '<documentId>'`), with the actual document that is referenced. This is done automatically for regular fields, but within raw fields, you have to explicitly enable this behavior, by using the field-level `resolveReferences` argument:
+
+```graphql
+{
+  allSanityProject {
+    edges {
+      node {
+        _rawTasks(resolveReferences: {maxDepth: 5})
+      }
+    }
+  }
+}
+```
+
 ## Portable Text / Block Content
 
 Rich text in Sanity is usually represented as [Portable Text](https://www.portabletext.org/) (previously known as "Block Content").

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -195,7 +195,7 @@ export const setFieldsOnGraphQLNodeType = async (
           materializeReferences: {type: GraphQLBoolean, defaultValue: false}
         },
         resolve: (obj: {[key: string]: {}}, args) => {
-          const raw = `_${camelCase(`raw_data_${field.aliasFor}`)}`
+          const raw = `_${camelCase(`raw_data_${field.aliasFor || fieldName}`)}`
           const value = obj[raw] || obj[fieldName] || obj[aliasFor]
           return args.materializeReferences
             ? materializeReferences(value, context, pluginConfig)
@@ -214,7 +214,7 @@ export const setFieldsOnGraphQLNodeType = async (
         materializeReferences: {type: GraphQLBoolean, defaultValue: false}
       },
       resolve: (obj: {[key: string]: {}}, args) => {
-        const raw = `_${camelCase(`raw_data_${field.aliasFor}`)}`
+        const raw = `_${camelCase(`raw_data_${field.aliasFor || fieldName}`)}`
         const value = obj[raw] || obj[aliasName] || obj[fieldName]
         return args.materializeReferences
           ? materializeReferences(value, context, pluginConfig)

--- a/src/util/normalize.ts
+++ b/src/util/normalize.ts
@@ -77,7 +77,7 @@ export function processDocument(doc: SanityDocument, options: ProcessingOptions)
 }
 
 // `drafts.foo-bar` => `foo.bar`
-function unprefixDraftId(id: string) {
+export function unprefixDraftId(id: string) {
   return id.replace(/^drafts\./, '')
 }
 


### PR DESCRIPTION
This PR adds a `materializeReferences` argument to raw fields, which will recursively replace any objects containing `_ref` with the referenced node, if it can be found. 

Since the return value is untyped, there is unfortunately no way to use image fragments and such, but this is still useful in a bunch of other contexts.

The argument is `false` by default in order to maintain backwards compatibility.