### PR TITLE
Set node internal content

### DIFF
--- a/src/util/normalize.ts
+++ b/src/util/normalize.ts
@@ -59,6 +59,7 @@ export function processDocument(doc: SanityDocument, options: ProcessingOptions)
     internal: {
       mediaType: 'application/json',
       type: getTypeName(doc._type),
+      content: JSON.stringify(withRefs),
       contentDigest: createContentDigest(JSON.stringify(withRefs))
     }
   }


### PR DESCRIPTION
Fixes #17.  

Could also set this to `"{}"` for better performance and to save memory, since you don't appear to use it. 