### PR TITLE
Explicitly declare field resolvers for union fields

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -13,7 +13,13 @@ import {
   GraphQLNonNull,
 } from 'gatsby/graphql'
 import SanityClient = require('@sanity/client')
-import {GatsbyContext, GatsbyReporter, GatsbyNode, GatsbyOnNodeTypeContext} from './types/gatsby'
+import {
+  GatsbyContext,
+  GatsbyReporter,
+  GatsbyNode,
+  GatsbyOnNodeTypeContext,
+  GatsbyResolversCreator,
+} from './types/gatsby'
 import {SanityDocument} from './types/sanity'
 import {pump} from './util/pump'
 import {rejectOnApiError} from './util/rejectOnApiError'
@@ -32,6 +38,7 @@ import {
 import debug from './debug'
 import {extendImageNode} from './images/extendImageNode'
 import {rewriteGraphQLSchema} from './util/rewriteGraphQLSchema'
+import {getGraphQLResolverMap} from './util/getGraphQLResolverMap'
 
 export interface PluginConfig {
   projectId: string
@@ -86,6 +93,15 @@ export const onPreBootstrap = async (context: GatsbyContext, pluginConfig: Plugi
       reporter.panic(err.stack)
     }
   }
+}
+
+export const createResolvers = (
+  actions: {createResolvers: GatsbyResolversCreator},
+  pluginConfig: PluginConfig,
+) => {
+  const typeMapKey = getCacheKey(pluginConfig, CACHE_KEYS.TYPE_MAP)
+  const typeMap = (stateCache[typeMapKey] || defaultTypeMap) as TypeMap
+  actions.createResolvers(getGraphQLResolverMap(typeMap))
 }
 
 export const sourceNodes = async (context: GatsbyContext, pluginConfig: PluginConfig) => {

--- a/src/types/gatsby.ts
+++ b/src/types/gatsby.ts
@@ -1,4 +1,4 @@
-import {GraphQLSchema, GraphQLNamedType} from 'graphql'
+import {GraphQLSchema, GraphQLNamedType, GraphQLFieldResolver} from 'graphql'
 
 interface GatsbyEventEmitter {
   on: (event: String, fn: Function) => null
@@ -45,7 +45,26 @@ export interface GatsbyDeleteOptions {
   node: GatsbyNode
 }
 
+export type GatsbyNodeModel = {
+  getNodeById: (args: {id: string}) => GatsbyNode
+}
+
+export type GatsbyGraphQLContext = {
+  nodeModel: GatsbyNodeModel
+}
+
 export type GatsbyTypesCreator = (types: string) => null
+
+export type GatsbyResolverMap = {
+  [typeName: string]: {
+    [fieldName: string]: {
+      type?: string
+      resolve: GraphQLFieldResolver<{[key: string]: any}, GatsbyGraphQLContext>
+    }
+  }
+}
+
+export type GatsbyResolversCreator = (resolvers: GatsbyResolverMap) => null
 
 export type GatsbyNodeCreator = (node: GatsbyNode) => null
 
@@ -92,6 +111,7 @@ export interface GatsbyContext {
 
 export interface GatsbyActions {
   createTypes: GatsbyTypesCreator
+  createResolvers: GatsbyResolversCreator
   createNode: GatsbyNodeCreator
   deleteNode: GatsbyNodeDeletor
   createParentChildLink: GatsbyParentChildLinker

--- a/src/types/sanity.ts
+++ b/src/types/sanity.ts
@@ -4,6 +4,10 @@ export interface SanityDocument {
   [key: string]: any
 }
 
+export interface SanityRef {
+  _ref: string
+}
+
 export interface ApiError {
   statusCode: number
   error: string

--- a/src/util/getGraphQLResolverMap.ts
+++ b/src/util/getGraphQLResolverMap.ts
@@ -1,0 +1,38 @@
+import {TypeMap} from './remoteGraphQLSchema'
+import {GatsbyResolverMap} from '../types/gatsby'
+import {getTypeName} from './normalize'
+
+export function getGraphQLResolverMap(typeMap: TypeMap): GatsbyResolverMap {
+  // Find all fields pointing to unions
+  const resolvers: GatsbyResolverMap = {}
+  Object.keys(typeMap.objects).forEach(typeName => {
+    const objectType = typeMap.objects[typeName]
+    const unionFields = Object.keys(objectType.fields)
+      .map(fieldName => ({fieldName, ...objectType.fields[fieldName]}))
+      .filter(field => typeMap.unions[getTypeName(field.namedType.name.value)])
+
+    if (!unionFields.length) {
+      return
+    }
+
+    resolvers[objectType.name] = unionFields.reduce((fields, field) => {
+      fields[field.fieldName] = {
+        resolve: (source, args, context) => {
+          if (field.isList) {
+            const ids: string[] = source[`${field.fieldName}___NODE`] || []
+            return ids && Array.isArray(ids)
+              ? ids.map(id => context.nodeModel.getNodeById({id}))
+              : []
+          }
+
+          const id: string | undefined = source[`${field.fieldName}___NODE`]
+          return id ? context.nodeModel.getNodeById({id}) : null
+        },
+      }
+
+      return fields
+    }, resolvers[objectType.name] || {})
+  })
+
+  return resolvers
+}


### PR DESCRIPTION
Fixes #15

When a field is a union type, it currently seems to always resolve to null.
This PR adds resolvers to all fields which is of a union type, and explicitly resolves them using `getNodeById`.

