### PR TITLE
Preserve asset IDs, rewire raw fields on resolved references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes will be documented in this file.
 
+## 5.0.0-alpha
+
+### BREAKING
+
+- `resolveReferences` no longer returns `_raw` fields - they are mapped to their original field names instead
+- `resolveReferences` returns `null` if the reference cannot be resolved
+- Image and file asset documents maintain their original document ID instead of remapping to a Gatsby node ID in UUID shape
+
 ## 4.0.5
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Remember to use the GraphiQL interface to help write the queries you need - it's
 
 Arrays and object types at the root of documents will get an additional "raw JSON" representation in a field called `_raw<FieldName>`. For instance, a field named `body` will be mapped to `_rawBody`. It's important to note that this is only done for top-level nodes (documents).
 
-Quite often, you'll want to replace reference fields (eg `_ref: '<documentId>'`, or `someField___NODE: '<documentId>'`), with the actual document that is referenced. This is done automatically for regular fields, but within raw fields, you have to explicitly enable this behavior, by using the field-level `resolveReferences` argument:
+Quite often, you'll want to replace reference fields (eg `_ref: '<documentId>'`), with the actual document that is referenced. This is done automatically for regular fields, but within raw fields, you have to explicitly enable this behavior, by using the field-level `resolveReferences` argument:
 
 ```graphql
 {

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -154,8 +154,8 @@ export const sourceNodes = async (context: GatsbyContext, pluginConfig: PluginCo
         return
       }
 
-      debug('Got document with ID %s', doc._id)
-      processDocument(doc, processingOptions)
+      const node = processDocument(doc, processingOptions)
+      debug('Got document with ID %s (mapped to %s)', doc._id, node.id)
       cb()
     }),
   ])

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -27,7 +27,7 @@ import {processDocument, getTypeName} from './util/normalize'
 import {getDocumentStream} from './util/getDocumentStream'
 import {getCacheKey, CACHE_KEYS} from './util/cache'
 import {removeSystemDocuments} from './util/removeSystemDocuments'
-import {removeDrafts, extractDrafts, unprefixId} from './util/handleDrafts'
+import {removeDrafts, extractDrafts} from './util/handleDrafts'
 import {handleListenerEvent, ListenerMessage} from './util/handleListenerEvent'
 import {
   getTypeMapFromGraphQLSchema,
@@ -40,6 +40,7 @@ import {extendImageNode} from './images/extendImageNode'
 import {resolveReferences} from './util/resolveReferences'
 import {rewriteGraphQLSchema} from './util/rewriteGraphQLSchema'
 import {getGraphQLResolverMap} from './util/getGraphQLResolverMap'
+import {unprefixId} from './util/documentIds'
 
 export interface PluginConfig {
   projectId: string

--- a/src/util/documentIds.ts
+++ b/src/util/documentIds.ts
@@ -1,0 +1,7 @@
+export function isDraftId(id: string) {
+  return id.startsWith('drafts.')
+}
+
+export const prefixId = (id: string) => (id.startsWith('drafts.') ? id : `drafts.${id}`)
+
+export const unprefixId = (id: string) => id.replace(/^drafts\./, '')

--- a/src/util/documentIds.ts
+++ b/src/util/documentIds.ts
@@ -5,3 +5,7 @@ export function isDraftId(id: string) {
 export const prefixId = (id: string) => (id.startsWith('drafts.') ? id : `drafts.${id}`)
 
 export const unprefixId = (id: string) => id.replace(/^drafts\./, '')
+
+export const safeId = (id: string, makeSafe: (id: string) => string) => {
+  return /^(image|file)-[a-z0-9]{32,}-/.test(id) ? id : makeSafe(id)
+}

--- a/src/util/handleDrafts.ts
+++ b/src/util/handleDrafts.ts
@@ -1,21 +1,14 @@
 import * as through from 'through2'
 import {SanityDocument} from '../types/sanity'
+import {isDraftId} from './documentIds'
 
 function filter(doc: SanityDocument, enc: string, callback: through.TransformCallback) {
   return isDraft(doc) ? callback() : callback(null, doc)
 }
 
-export function isDraftId(id: string) {
-  return id.startsWith('drafts.')
-}
-
 export function isDraft(doc: SanityDocument) {
   return doc && doc._id && isDraftId(doc._id)
 }
-
-export const prefixId = (id: string) => (id.startsWith('drafts.') ? id : `drafts.${id}`)
-
-export const unprefixId = (id: string) => id.replace(/^drafts\./, '')
 
 export const removeDrafts = () => through.obj(filter)
 

--- a/src/util/handleListenerEvent.ts
+++ b/src/util/handleListenerEvent.ts
@@ -2,8 +2,8 @@ import debug from '../debug'
 import {SanityDocument} from '../types/sanity'
 import {GatsbyContext, GatsbyNode} from '../types/gatsby'
 import {processDocument, ProcessingOptions} from './normalize'
-import {isDraftId, unprefixId} from './handleDrafts'
 import {removeGatsbyInternalProps} from './removeGatsbyInternalProps'
+import {unprefixId, isDraftId} from './documentIds'
 
 export interface ListenerMessage {
   documentId: string

--- a/src/util/handleListenerEvent.ts
+++ b/src/util/handleListenerEvent.ts
@@ -3,7 +3,7 @@ import {SanityDocument} from '../types/sanity'
 import {GatsbyContext, GatsbyNode} from '../types/gatsby'
 import {processDocument, ProcessingOptions} from './normalize'
 import {removeGatsbyInternalProps} from './removeGatsbyInternalProps'
-import {unprefixId, isDraftId} from './documentIds'
+import {unprefixId, isDraftId, safeId} from './documentIds'
 
 export interface ListenerMessage {
   documentId: string
@@ -20,7 +20,7 @@ export function handleListenerEvent(
   const {actions, createNodeId, getNode} = context
   const {createNode, deleteNode} = actions
   const {overlayDrafts} = processingOptions
-  const current = getNode(createNodeId(unprefixId(event.documentId)))
+  const current = getNode(safeId(unprefixId(event.documentId), createNodeId))
 
   let published = publishedNodes.get(unprefixId(event.documentId))
   if (published) {

--- a/src/util/normalize.ts
+++ b/src/util/normalize.ts
@@ -2,6 +2,7 @@ import {set, startCase, camelCase, cloneDeep, upperFirst} from 'lodash'
 import {extractWithPath} from '@sanity/mutator'
 import {specifiedScalarTypes} from 'gatsby/graphql'
 import {SanityDocument} from '../types/sanity'
+import {safeId} from './documentIds'
 import {unprefixDraftId} from './unprefixDraftId'
 import {TypeMap} from './remoteGraphQLSchema'
 import {
@@ -40,7 +41,7 @@ export function processDocument(doc: SanityDocument, options: ProcessingOptions)
   const node = {
     ...withRefs,
     ...rawAliases,
-    id: createNodeId(overlayDrafts ? unprefixDraftId(doc._id) : doc._id),
+    id: safeId(overlayDrafts ? unprefixDraftId(doc._id) : doc._id, createNodeId),
     parent: null,
     children: [],
     internal: {
@@ -124,7 +125,7 @@ function rewriteNodeReferences(doc: SanityDocument, options: ProcessingOptions) 
 
   const newDoc = cloneDeep(doc)
   refs.forEach(match => {
-    set(newDoc, match.path, createNodeId(match.value))
+    set(newDoc, match.path, safeId(match.value, createNodeId))
   })
 
   return newDoc

--- a/src/util/resolveReferences.ts
+++ b/src/util/resolveReferences.ts
@@ -47,33 +47,10 @@ export function resolveReferences(
 
   const initial: {[key: string]: any} = {}
   return Object.keys(obj).reduce((acc, key) => {
-    const isGatsbyRef = key.endsWith('___NODE')
     const isRawDataField = key.startsWith('_rawData')
-    let targetKey = isGatsbyRef && currentDepth <= maxDepth ? key.slice(0, -7) : key
-
-    let value = obj[key]
-    if (isGatsbyRef && currentDepth <= maxDepth) {
-      value = resolveGatsbyReference(obj[key], context)
-    }
-
-    value = resolveReferences(value, context, resolveOptions, currentDepth + 1)
-
-    if (isRawDataField) {
-      targetKey = `_raw${key.slice(8)}`
-    }
-
+    const value = resolveReferences(obj[key], context, resolveOptions, currentDepth + 1)
+    const targetKey = isRawDataField ? `_raw${key.slice(8)}` : key
     acc[targetKey] = value
     return acc
   }, initial)
-}
-
-function resolveGatsbyReference(value: string | string[], context: MinimalGatsbyContext) {
-  const {getNode} = context
-  if (typeof value === 'string') {
-    return getNode(value)
-  } else if (Array.isArray(value)) {
-    return value.map(id => getNode(id))
-  } else {
-    throw new Error(`Unknown Gatsby node reference: ${value}`)
-  }
 }

--- a/src/util/resolveReferences.ts
+++ b/src/util/resolveReferences.ts
@@ -1,5 +1,7 @@
 import {GatsbyNode, GatsbyNodeIdCreator} from '../types/gatsby'
 import {unprefixDraftId} from './unprefixDraftId'
+import {safeId} from './documentIds'
+import debug from '../debug'
 
 const defaultResolveOptions: ResolveReferencesOptions = {
   maxDepth: 5,
@@ -38,8 +40,10 @@ export function resolveReferences(
   }
 
   if (typeof obj._ref === 'string') {
-    const id = obj._ref
-    const node = getNode(createNodeId(overlayDrafts ? unprefixDraftId(id) : id))
+    const targetId = safeId(overlayDrafts ? unprefixDraftId(obj._ref) : obj._ref, createNodeId)
+    debug('Resolve %s (Sanity ID %s)', targetId, obj._ref)
+
+    const node = getNode(targetId)
     return node && currentDepth <= maxDepth
       ? resolveReferences(node, context, resolveOptions, currentDepth + 1)
       : obj

--- a/test/resolveReferences.test.ts
+++ b/test/resolveReferences.test.ts
@@ -1,5 +1,12 @@
 import {resolveReferences} from '../src/util/resolveReferences'
 
+function reverse(id: string) {
+  return id
+    .split('')
+    .reverse()
+    .join('')
+}
+
 const createNodeId = (id: string) => id
 
 test('resolves Sanity references', () => {
@@ -40,7 +47,7 @@ test('uses draft id if overlayDrafts is set to false', () => {
       {maxDepth: 5, overlayDrafts: false},
     ),
   ).toEqual({
-    foo: {_ref: `drafts.${_id}`},
+    foo: null,
   })
 })
 
@@ -87,5 +94,35 @@ test('resolves to max depth specified', () => {
       },
       id: 'abc123',
     },
+  })
+})
+
+test('remaps raw fields from returned nodes', () => {
+  const _id = 'abc123'
+  const getNode = (id: string) => {
+    switch (id) {
+      case '321cba':
+        return {
+          _id,
+          id: '321cba',
+          bar: 'baz',
+          foo: [{_ref: 'gatsbyId'}],
+          _rawDataFoo: [{_ref: 'def'}],
+        }
+      case 'fed':
+        return {_id: 'def', id: 'fed', its: 'def'}
+      default:
+        return undefined
+    }
+  }
+
+  expect(
+    resolveReferences(
+      {foo: [{_ref: _id}]},
+      {createNodeId: reverse, getNode},
+      {maxDepth: 5, overlayDrafts: true},
+    ),
+  ).toEqual({
+    foo: [{_id, id: '321cba', bar: 'baz', foo: [{_id: 'def', id: 'fed', its: 'def'}]}],
   })
 })

--- a/test/resolveReferences.test.ts
+++ b/test/resolveReferences.test.ts
@@ -44,34 +44,6 @@ test('uses draft id if overlayDrafts is set to false', () => {
   })
 })
 
-test('resolves Gatsby references', () => {
-  const _id = 'abc123'
-  const getNode = (id: string) => (id === 'abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
-  expect(
-    resolveReferences(
-      {foo___NODE: _id},
-      {createNodeId, getNode},
-      {maxDepth: 5, overlayDrafts: true},
-    ),
-  ).toEqual({
-    foo: {_id, id: _id, bar: 'baz'},
-  })
-})
-
-test('resolves Gatsby array references', () => {
-  const _id = 'abc123'
-  const getNode = (id: string) => (id === 'abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
-  expect(
-    resolveReferences(
-      {foo___NODE: [_id]},
-      {createNodeId, getNode},
-      {maxDepth: 5, overlayDrafts: true},
-    ),
-  ).toEqual({
-    foo: [{_id, id: _id, bar: 'baz'}],
-  })
-})
-
 test('resolves references in arrays', () => {
   const _id = 'abc123'
   const getNode = (id: string) => (id === 'abc123' ? {_id, id: _id, bar: 'baz'} : undefined)


### PR DESCRIPTION
This PR checks if a document ID matches the asset ID pattern we use in Sanity, and if so, preserves it. This ensures that using it with the image-url library and similar is easier, as you don't need to materialize references to get at the asset document ID.

I also:
- Removed the old Gatsby references resolving, as it was no longer used. Hooray for removing dead code!
- Rewired `_rawSomeFieldName` in resolved, referenced nodes to their original field name (eg `_rawSections` =>  `sections`)
- Broken references now return `null` instead of the reference object, making it easier to see when resolving fails
