### PR TITLE
Apply resolvers to conflict-free restricted fields

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -80,7 +80,7 @@ export const onPreBootstrap = async (context: GatsbyContext, pluginConfig: Plugi
     const api = await getRemoteGraphQLSchema(client, config)
 
     reporter.info('[sanity] Transforming to Gatsby-compatible GraphQL SDL')
-    const graphqlSdl = await rewriteGraphQLSchema(api, config)
+    const graphqlSdl = await rewriteGraphQLSchema(api, {config, reporter})
     const graphqlSdlKey = getCacheKey(pluginConfig, CACHE_KEYS.GRAPHQL_SDL)
     stateCache[graphqlSdlKey] = graphqlSdl
 
@@ -147,7 +147,9 @@ export const sourceNodes = async (context: GatsbyContext, pluginConfig: PluginCo
       const type = getTypeName(doc._type)
       if (!typeMap.objects[type]) {
         reporter.warn(
-          `[sanity] Document "${doc._id}" has type ${doc._type} (${type}), which is not declared in the GraphQL schema. Make sure you run "graphql deploy". Skipping document.`,
+          `[sanity] Document "${doc._id}" has type ${
+            doc._type
+          } (${type}), which is not declared in the GraphQL schema. Make sure you run "graphql deploy". Skipping document.`,
         )
 
         cb()

--- a/src/util/getGraphQLResolverMap.ts
+++ b/src/util/getGraphQLResolverMap.ts
@@ -1,6 +1,6 @@
 import {TypeMap, FieldDef} from './remoteGraphQLSchema'
 import {GatsbyResolverMap, GatsbyNodeModel, GatsbyGraphQLContext} from '../types/gatsby'
-import {getTypeName} from './normalize'
+import {getTypeName, getConflictFreeFieldName} from './normalize'
 import {SanityRef} from '../types/sanity'
 import {GraphQLFieldResolver} from 'graphql'
 
@@ -23,7 +23,8 @@ export function getGraphQLResolverMap(typeMap: TypeMap): GatsbyResolverMap {
     }
 
     resolvers[objectType.name] = resolveFields.reduce((fields, field) => {
-      fields[field.fieldName] = {resolve: getResolver(field)}
+      const targetField = getConflictFreeFieldName(field.fieldName)
+      fields[targetField] = {resolve: getResolver(field)}
       return fields
     }, resolvers[objectType.name] || {})
   })

--- a/src/util/normalize.ts
+++ b/src/util/normalize.ts
@@ -79,14 +79,17 @@ function prefixConflictingKeys(obj: SanityDocument) {
   const initial: SanityDocument = {_id: '', _type: ''}
 
   return Object.keys(obj).reduce((target, key) => {
-    if (RESTRICTED_NODE_FIELDS.includes(key)) {
-      target[`${camelCase(typePrefix)}${upperFirst(key)}`] = obj[key]
-    } else {
-      target[key] = obj[key]
-    }
+    const targetKey = getConflictFreeFieldName(key)
+    target[targetKey] = obj[key]
 
     return target
   }, initial)
+}
+
+export function getConflictFreeFieldName(fieldName: string) {
+  return RESTRICTED_NODE_FIELDS.includes(fieldName)
+    ? `${camelCase(typePrefix)}${upperFirst(fieldName)}`
+    : fieldName
 }
 
 function getRawAliases(doc: SanityDocument, options: ProcessingOptions) {


### PR DESCRIPTION
Fixes #39.

Gatsby has some properties which are considered "internal", or rather, they have a special meaning and should not be used. These are the following: id, parent, children, fields, internal.

When these occur in the schema (and data), we rename the fields to include a `sanity` prefix - in other words, `internal` becomes `sanityInternal`.

However, when you had a field which needed the prefix which _also_ needed a custom resolver (such as an array or a reference), the resolver would get applied to the unprefixed field, causing Gatsby to crash on build, as we were trying to change the output type of the field.

I also took the liberty of adding warnings when we rename conflicting fields, as this can be quite confusing to users.