### PR TITLE
Allow specifying GraphQL API tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,14 @@ module.exports = {
       options: {
         projectId: 'abc123',
         dataset: 'blog',
+
         // a token with read permissions is required
         // if you have a private dataset
         token: process.env.MY_SANITY_TOKEN,
+
+        // If the Sanity GraphQL API was deployed using `--tag <name>`,
+        // use `graphqlTag` to specify the tag name. Defaults to `default`.
+        graphqlTag: 'default',
       },
     },
   ],
@@ -62,13 +67,14 @@ Explore http://localhost:8000/___graphql after running `gatsby develop` to under
 
 ## Options
 
-| Options       | Type    | Default | Description                                                                                                                                                        |
-| ------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| projectId     | string  |         | **[required]** Your Sanity project's ID                                                                                                                            |
-| dataset       | string  |         | **[required]** The dataset to fetch from                                                                                                                           |
-| token         | string  |         | Authentication token for fetching data from private datasets, or when using `overlayDrafts` [Learn more](https://www.sanity.io/docs/http-auth)                     |
-| overlayDrafts | boolean | `false` | Set to `true` in order for drafts to replace their published version. By default, drafts will be skipped.                                                          |
-| watchMode     | boolean | `false` | Set to `true` to keep a listener open and update with the latest changes in realtime. If you add a `token` you will get all content updates down to each keypress. |
+| Options       | Type    | Default   | Description                                                                                                                                                        |
+| ------------- | ------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| projectId     | string  |           | **[required]** Your Sanity project's ID                                                                                                                            |
+| dataset       | string  |           | **[required]** The dataset to fetch from                                                                                                                           |
+| token         | string  |           | Authentication token for fetching data from private datasets, or when using `overlayDrafts` [Learn more](https://www.sanity.io/docs/http-auth)                     |
+| graphqlTag    | string  | `default` | If the Sanity GraphQL API was deployed using `--tag <name>`, use this to specify the tag name.                                                                     |
+| overlayDrafts | boolean | `false`   | Set to `true` in order for drafts to replace their published version. By default, drafts will be skipped.                                                          |
+| watchMode     | boolean | `false`   | Set to `true` to keep a listener open and update with the latest changes in realtime. If you add a `token` you will get all content updates down to each keypress. |
 
 ## Preview of unpublished content
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -47,7 +47,7 @@ export interface PluginConfig {
   dataset: string
   token?: string
   version?: string
-  graphqlApi: string
+  graphqlTag: string
   overlayDrafts?: boolean
   watchMode?: boolean
 }
@@ -55,7 +55,7 @@ export interface PluginConfig {
 const defaultConfig = {
   version: '1',
   overlayDrafts: false,
-  graphqlApi: 'default',
+  graphqlTag: 'default',
 }
 
 const stateCache: {[key: string]: any} = {}

--- a/src/util/remoteGraphQLSchema.ts
+++ b/src/util/remoteGraphQLSchema.ts
@@ -50,11 +50,11 @@ export const defaultTypeMap: TypeMap = {
 }
 
 export async function getRemoteGraphQLSchema(client: SanityClient, config: PluginConfig) {
-  const {graphqlApi} = config
+  const {graphqlTag} = config
   const {dataset} = client.config()
   try {
     const api = await client.request({
-      url: `/apis/graphql/${dataset}/${graphqlApi}`,
+      url: `/apis/graphql/${dataset}/${graphqlTag}`,
       headers: {Accept: 'application/graphql'},
     })
 


### PR DESCRIPTION
This adds support for specifying the GraphQL API tag name to use for introspecting the schema.