### PR TITLE
Fix bug where non-document types would get rewritten fields

### DIFF
--- a/src/util/getGraphQLResolverMap.ts
+++ b/src/util/getGraphQLResolverMap.ts
@@ -12,10 +12,9 @@ export function getGraphQLResolverMap(typeMap: TypeMap): GatsbyResolverMap {
       .map(fieldName => ({fieldName, ...objectType.fields[fieldName]}))
       .filter(
         field =>
-          field.fieldName !== 'children' &&
-          (field.isList ||
-            field.isReference ||
-            typeMap.unions[getTypeName(field.namedType.name.value)]),
+          field.isList ||
+          field.isReference ||
+          typeMap.unions[getTypeName(field.namedType.name.value)],
       )
 
     if (!resolveFields.length) {
@@ -23,7 +22,10 @@ export function getGraphQLResolverMap(typeMap: TypeMap): GatsbyResolverMap {
     }
 
     resolvers[objectType.name] = resolveFields.reduce((fields, field) => {
-      const targetField = getConflictFreeFieldName(field.fieldName)
+      const targetField = objectType.isDocument
+        ? getConflictFreeFieldName(field.fieldName)
+        : field.fieldName
+
       fields[targetField] = {resolve: getResolver(field)}
       return fields
     }, resolvers[objectType.name] || {})


### PR DESCRIPTION
If you have a non-document type with fields that are reserved (`id`, for instance), the field would still get renamed, even though it doesn't implement the `Node` interface. To make things worse, the renaming of _data_ is not done recursively, so you would be unable to query these fields.

This also fixes the issue where users were seeing a warning about the `SanityImageAssetSource` having a `id` attribute upon build. 

This is actually a breaking change, as some people might be relying on the `sanity`-prefixed field names, so I guess this calls for a major release.

Fixes #63