### PR TITLE
Re-implement aliases, allowing deep, raw aliases

### DIFF
--- a/src/types/gatsby.ts
+++ b/src/types/gatsby.ts
@@ -53,6 +53,11 @@ export type GatsbyGraphQLContext = {
   nodeModel: GatsbyNodeModel
 }
 
+export interface MinimalGatsbyContext {
+  createNodeId: GatsbyNodeIdCreator
+  getNode: (id: string) => GatsbyNode | undefined
+}
+
 export type GatsbyTypesCreator = (types: string) => null
 
 export type GatsbyResolverMap = {

--- a/src/util/documentIds.ts
+++ b/src/util/documentIds.ts
@@ -7,5 +7,10 @@ export const prefixId = (id: string) => (id.startsWith('drafts.') ? id : `drafts
 export const unprefixId = (id: string) => id.replace(/^drafts\./, '')
 
 export const safeId = (id: string, makeSafe: (id: string) => string) => {
-  return /^(image|file)-[a-z0-9]{32,}-/.test(id) ? id : makeSafe(id)
+  return /^(image|file)-[a-z0-9]{32,}-/.test(id)
+    ? // Use raw IDs for assets as we might use these with asset tooling
+      id
+    : // Prefix Gatsbyfied IDs with a dash as it's not allowed in Sanity,
+      // thus enabling easy checks for Gatsby vs Sanity IDs
+      `-${makeSafe(id)}`
 }

--- a/src/util/resolveReferences.ts
+++ b/src/util/resolveReferences.ts
@@ -1,16 +1,11 @@
-import {GatsbyNode, GatsbyNodeIdCreator} from '../types/gatsby'
-import {unprefixDraftId} from './unprefixDraftId'
-import {safeId} from './documentIds'
+import {MinimalGatsbyContext} from '../types/gatsby'
 import debug from '../debug'
+import {safeId} from './documentIds'
+import {unprefixDraftId} from './unprefixDraftId'
 
 const defaultResolveOptions: ResolveReferencesOptions = {
   maxDepth: 5,
   overlayDrafts: false,
-}
-
-interface MinimalGatsbyContext {
-  createNodeId: GatsbyNodeIdCreator
-  getNode: (id: string) => GatsbyNode | undefined
 }
 
 interface ResolveReferencesOptions {
@@ -40,7 +35,13 @@ export function resolveReferences(
   }
 
   if (typeof obj._ref === 'string') {
-    const targetId = safeId(overlayDrafts ? unprefixDraftId(obj._ref) : obj._ref, createNodeId)
+    const targetId =
+      // If the reference starts with a '-', it means it's a Gatsby node ID,
+      // not a Sanity document ID. Thus, it does not need to be rewritten
+      obj._ref.startsWith('-')
+        ? obj._ref
+        : safeId(overlayDrafts ? unprefixDraftId(obj._ref) : obj._ref, createNodeId)
+
     debug('Resolve %s (Sanity ID %s)', targetId, obj._ref)
 
     const node = getNode(targetId)

--- a/test/resolveReferences.test.ts
+++ b/test/resolveReferences.test.ts
@@ -11,7 +11,7 @@ const createNodeId = (id: string) => id
 
 test('resolves Sanity references', () => {
   const _id = 'abc123'
-  const getNode = (id: string) => (id === 'abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
+  const getNode = (id: string) => (id === '-abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
   expect(
     resolveReferences(
       {foo: {_ref: _id}},
@@ -25,7 +25,7 @@ test('resolves Sanity references', () => {
 
 test('uses non-draft if overlayDrafts is set to true', () => {
   const _id = 'abc123'
-  const getNode = (id: string) => (id === 'abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
+  const getNode = (id: string) => (id === '-abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
   expect(
     resolveReferences(
       {foo: {_ref: `drafts.${_id}`}},
@@ -39,7 +39,7 @@ test('uses non-draft if overlayDrafts is set to true', () => {
 
 test('uses draft id if overlayDrafts is set to false', () => {
   const _id = 'abc123'
-  const getNode = (id: string) => (id === 'abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
+  const getNode = (id: string) => (id === '-abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
   expect(
     resolveReferences(
       {foo: {_ref: `drafts.${_id}`}},
@@ -53,7 +53,7 @@ test('uses draft id if overlayDrafts is set to false', () => {
 
 test('resolves references in arrays', () => {
   const _id = 'abc123'
-  const getNode = (id: string) => (id === 'abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
+  const getNode = (id: string) => (id === '-abc123' ? {_id, id: _id, bar: 'baz'} : undefined)
   expect(
     resolveReferences(
       {foo: [{_ref: _id}]},
@@ -68,7 +68,7 @@ test('resolves references in arrays', () => {
 test('resolves to max depth specified', () => {
   const _id = 'abc123'
   const node = {_id, id: _id, bar: 'baz', child: {_ref: _id}}
-  const getNode = (id: string) => (id === 'abc123' ? node : undefined)
+  const getNode = (id: string) => (id === '-abc123' ? node : undefined)
   expect(
     resolveReferences(
       {foo: {_ref: _id}},
@@ -98,19 +98,20 @@ test('resolves to max depth specified', () => {
 })
 
 test('remaps raw fields from returned nodes', () => {
-  const _id = 'abc123'
+  const _id = 'abc123' // Sanity ID
+  const id = '-321cba' // Gatsby ID
   const getNode = (id: string) => {
     switch (id) {
-      case '321cba':
+      case '-321cba':
         return {
           _id,
-          id: '321cba',
+          id,
           bar: 'baz',
-          foo: [{_ref: 'gatsbyId'}],
+          foo: [{_ref: '-gatsbyId'}],
           _rawDataFoo: [{_ref: 'def'}],
         }
-      case 'fed':
-        return {_id: 'def', id: 'fed', its: 'def'}
+      case '-fed':
+        return {_id: 'def', id: '-fed', its: 'def'}
       default:
         return undefined
     }
@@ -123,6 +124,6 @@ test('remaps raw fields from returned nodes', () => {
       {maxDepth: 5, overlayDrafts: true},
     ),
   ).toEqual({
-    foo: [{_id, id: '321cba', bar: 'baz', foo: [{_id: 'def', id: 'fed', its: 'def'}]}],
+    foo: [{_id, id, bar: 'baz', foo: [{_id: 'def', id: '-fed', its: 'def'}]}],
   })
 })


### PR DESCRIPTION
Roughly speaking, if you have a complex field (such as a portable text field) that is not at the root level of a document, there is no way to only fetch that field in it's "raw" variant.

For instance, with the following schema:
```graphql
type TravelLog implements Document {
  title: String
  body: [Block]
  locations: [TravelLocation]
}

type TravelLocation {
  name: String
  description: [Block]
  highlights: [TravelLocationHighlight]
  geolocation: Geopoint
}

type TravelLocationHighlight {
  title: String
  description: [Block]
}
```

If you want to fetch travel log entries with their title and highlights only, there is no way to do that except to use the `_rawLocations` field on the `TravelLog` type, which would also give the `description` and `geolocation` field from the `TravelLocation` type, which we may not want. The _wanted_ behavior would be something like:

```graphql
{
  allSanityTravelLog {
    nodes {
      title
      locations {
        name
        highlights {
          title
          _rawDescription
        }
      }
    }
  }
}
```

This was a bit of a pain to fix, because we applied the raw field/resolvers on document nodes only by using a Gatsby action that only triggered for Gatsby _node_ types (document types, in Sanity's view). Thus, I had to lift the logic up so that the schema logic _defines_ the aliases, then have the resolver logic _implement_ the logic.

To make things harder, sometimes you are working with the "raw" Sanity document IDs (because we at the document level add an (internal) "raw data" field we can extract it from, but in deep structures the value is derived from it's parent, and thus has document IDs rewritten to Gatsby form. I think this should be cleaned up in the future - we probably want to just always use Gatsby IDs. The biggest issue with that are the Sanity asset IDs, which we use in portable text renderers etc. We may have to leave those alone.

For now, I decided that a temporary "solution" (albeit dirty) is to prefix "Gatsby"-IDs with a dash (`-`), as that is not allowed as the first character of Sanity document IDs. This way, we can check _when resolving references_ whether or not the reference should be rewritten.

This PR builds on some of my recent PRs, so will need to have those merged first.

Fixes #37

