### PR TITLE
Align image fragments with gatsby-image

### DIFF
--- a/src/images/extendImageNode.ts
+++ b/src/images/extendImageNode.ts
@@ -5,6 +5,7 @@ import {
   GraphQLInt,
   GraphQLFieldConfig,
   GraphQLEnumType,
+  GraphQLNonNull,
 } from 'gatsby/graphql'
 import {GatsbyContext, GatsbyOnNodeTypeContext} from '../types/gatsby'
 import {PluginConfig} from '../gatsby-node'
@@ -51,12 +52,11 @@ function getExtension(config: PluginConfig) {
     type: new GraphQLObjectType({
       name: 'SanityImageFixed',
       fields: {
+        width: {type: new GraphQLNonNull(GraphQLFloat)},
+        height: {type: new GraphQLNonNull(GraphQLFloat)},
+        src: {type: new GraphQLNonNull(GraphQLString)},
+        srcSet: {type: new GraphQLNonNull(GraphQLString)},
         base64: {type: GraphQLString},
-        aspectRatio: {type: GraphQLFloat},
-        width: {type: GraphQLFloat},
-        height: {type: GraphQLFloat},
-        src: {type: GraphQLString},
-        srcSet: {type: GraphQLString},
         srcWebp: {type: GraphQLString},
         srcSetWebp: {type: GraphQLString},
       },
@@ -81,13 +81,13 @@ function getExtension(config: PluginConfig) {
     type: new GraphQLObjectType({
       name: 'SanityImageFluid',
       fields: {
+        aspectRatio: {type: new GraphQLNonNull(GraphQLFloat)},
+        src: {type: new GraphQLNonNull(GraphQLString)},
+        srcSet: {type: new GraphQLNonNull(GraphQLString)},
+        sizes: {type: new GraphQLNonNull(GraphQLString)},
         base64: {type: GraphQLString},
-        aspectRatio: {type: GraphQLFloat},
-        src: {type: GraphQLString},
-        srcSet: {type: GraphQLString},
         srcWebp: {type: GraphQLString},
         srcSetWebp: {type: GraphQLString},
-        sizes: {type: GraphQLString},
       },
     }),
     args: {

--- a/src/images/getGatsbyImageProps.ts
+++ b/src/images/getGatsbyImageProps.ts
@@ -12,22 +12,28 @@ enum ImageFormat {
   PNG = 'png',
 }
 
-type GatsbyImageProps = {
-  base64: string | null
-  aspectRatio: number
-  src: string
-  srcWebp: string
-  srcSet: string
-  srcSetWebp: string
-}
-
-type GatsbyFixedImageProps = GatsbyImageProps & {
+interface GatsbyFixedImageProps {
   width: number
   height: number
+  src: string
+  srcSet: string
+  base64?: string
+  tracedSVG?: string
+  srcWebp?: string
+  srcSetWebp?: string
+  media?: string
 }
 
-type GatsbyFluidImageProps = GatsbyImageProps & {
+type GatsbyFluidImageProps = {
+  aspectRatio: number
+  src: string
+  srcSet: string
   sizes: string
+  base64?: string
+  tracedSVG?: string
+  srcWebp?: string
+  srcSetWebp?: string
+  media?: string
 }
 
 type ImageDimensions = {
@@ -217,8 +223,7 @@ export function getFixedGatsbyImage(
   const srcWebp = convertToFormat(imgUrl, 'webp')
 
   return {
-    base64: lqip || null,
-    aspectRatio: desiredAspectRatio,
+    base64: lqip || undefined,
     width: Math.round(width),
     height: outputHeight,
     src,
@@ -294,7 +299,7 @@ export function getFluidGatsbyImage(
     }, initial)
 
   return {
-    base64: lqip || null,
+    base64: lqip || undefined,
     aspectRatio: desiredAspectRatio,
     src,
     srcWebp,

--- a/test/__snapshots__/getGatsbyImageProps.test.ts.snap
+++ b/test/__snapshots__/getGatsbyImageProps.test.ts.snap
@@ -2,8 +2,7 @@
 
 exports[`[id] fixed, jpeg with width/height (50) < original size 1`] = `
 Object {
-  "aspectRatio": 1,
-  "base64": null,
+  "base64": undefined,
   "height": 50,
   "src": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?w=50&h=50&fit=crop",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?w=50&h=50&fit=crop 1x",
@@ -15,8 +14,7 @@ Object {
 
 exports[`[id] fixed, jpeg with width/height (300x300) > original size, same aspect 1`] = `
 Object {
-  "aspectRatio": 1,
-  "base64": null,
+  "base64": undefined,
   "height": 300,
   "src": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg 1x",
@@ -28,8 +26,7 @@ Object {
 
 exports[`[id] fixed, jpeg with width/height (320x240) > original size, different aspect 1`] = `
 Object {
-  "aspectRatio": 1.3333333333333333,
-  "base64": null,
+  "base64": undefined,
   "height": 240,
   "src": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?w=320&h=240&fit=crop",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?w=320&h=240&fit=crop 1x",
@@ -41,8 +38,7 @@ Object {
 
 exports[`[id] fixed, jpeg with width/height matching original 1`] = `
 Object {
-  "aspectRatio": 1,
-  "base64": null,
+  "base64": undefined,
   "height": 70,
   "src": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg 1x",
@@ -54,8 +50,7 @@ Object {
 
 exports[`[id] fixed, jpg with width (600) + height (300) 1`] = `
 Object {
-  "aspectRatio": 2,
-  "base64": null,
+  "base64": undefined,
   "height": 300,
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=600&h=300&fit=crop",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=600&h=300&fit=crop 1x",
@@ -67,8 +62,7 @@ Object {
 
 exports[`[id] fixed, jpg with width (600) 1`] = `
 Object {
-  "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "height": 400,
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg 1x",
@@ -80,8 +74,7 @@ Object {
 
 exports[`[id] fixed, jpg without params 1`] = `
 Object {
-  "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "height": 267,
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg 1x",
@@ -93,8 +86,7 @@ Object {
 
 exports[`[id] fixed, webp with width (600) + height (300) 1`] = `
 Object {
-  "aspectRatio": 2,
-  "base64": null,
+  "base64": undefined,
   "height": 300,
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=300&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=300&fit=crop&fm=jpg 1x,
@@ -112,8 +104,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1800&h=90
 
 exports[`[id] fixed, webp with width (600) 1`] = `
 Object {
-  "aspectRatio": 1.497175141242938,
-  "base64": null,
+  "base64": undefined,
   "height": 401,
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=401&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=401&fit=crop&fm=jpg 1x,
@@ -131,8 +122,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1800&h=12
 
 exports[`[id] fixed, webp without params 1`] = `
 Object {
-  "aspectRatio": 1.497175141242938,
-  "base64": null,
+  "base64": undefined,
   "height": 267,
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=400&h=267&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=400&h=267&fit=crop&fm=jpg 1x,
@@ -151,7 +141,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1200&h=80
 exports[`[id] fluid, jpeg with max width (300) > original size 1`] = `
 Object {
   "aspectRatio": 1,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 70px) 100vw, 70px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg 70w",
@@ -163,7 +153,7 @@ Object {
 exports[`[id] fluid, jpg with max width (1200) + max height (768) 1`] = `
 Object {
   "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 300px) 100vw, 300px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=150&h=100&fit=crop 150w,
@@ -177,7 +167,7 @@ https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?fm=webp 300w",
 exports[`[id] fluid, jpg with max width (1200) 1`] = `
 Object {
   "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 300px) 100vw, 300px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=150&h=100&fit=crop 150w,
@@ -191,7 +181,7 @@ https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?fm=webp 300w",
 exports[`[id] fluid, jpg without params 1`] = `
 Object {
   "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 300px) 100vw, 300px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=150&h=100&fit=crop 150w,
@@ -205,7 +195,7 @@ https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?fm=webp 300w",
 exports[`[id] fluid, webp with max width (1200) + max height (768) 1`] = `
 Object {
   "aspectRatio": 1.5625,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 1200px) 100vw, 1200px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1200&h=768&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=300&h=192&fit=crop&fm=jpg 300w,
@@ -229,7 +219,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=4240&h=27
 exports[`[id] fluid, webp with max width (1200) 1`] = `
 Object {
   "aspectRatio": 1.497175141242938,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 1200px) 100vw, 1200px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1200&h=802&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=300&h=200&fit=crop&fm=jpg 300w,
@@ -253,7 +243,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp 4240w",
 exports[`[id] fluid, webp without params 1`] = `
 Object {
   "aspectRatio": 1.497175141242938,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 800px) 100vw, 800px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=800&h=534&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=200&h=134&fit=crop&fm=jpg 200w,
@@ -276,8 +266,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp 4240w",
 
 exports[`[ref] fixed, jpg with width (600) + height (300) 1`] = `
 Object {
-  "aspectRatio": 2,
-  "base64": null,
+  "base64": undefined,
   "height": 300,
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=600&h=300&fit=crop",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=600&h=300&fit=crop 1x",
@@ -289,8 +278,7 @@ Object {
 
 exports[`[ref] fixed, jpg with width (600) 1`] = `
 Object {
-  "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "height": 400,
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg 1x",
@@ -302,8 +290,7 @@ Object {
 
 exports[`[ref] fixed, jpg without params 1`] = `
 Object {
-  "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "height": 267,
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg 1x",
@@ -315,8 +302,7 @@ Object {
 
 exports[`[ref] fixed, webp with width (600) + height (300) 1`] = `
 Object {
-  "aspectRatio": 2,
-  "base64": null,
+  "base64": undefined,
   "height": 300,
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=300&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=300&fit=crop&fm=jpg 1x,
@@ -334,8 +320,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1800&h=90
 
 exports[`[ref] fixed, webp with width (600) 1`] = `
 Object {
-  "aspectRatio": 1.497175141242938,
-  "base64": null,
+  "base64": undefined,
   "height": 401,
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=401&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=401&fit=crop&fm=jpg 1x,
@@ -353,8 +338,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1800&h=12
 
 exports[`[ref] fixed, webp without params 1`] = `
 Object {
-  "aspectRatio": 1.497175141242938,
-  "base64": null,
+  "base64": undefined,
   "height": 267,
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=400&h=267&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=400&h=267&fit=crop&fm=jpg 1x,
@@ -373,7 +357,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1200&h=80
 exports[`[ref] fluid, jpg with max width (1200) + max height (768) 1`] = `
 Object {
   "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 300px) 100vw, 300px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=150&h=100&fit=crop 150w,
@@ -387,7 +371,7 @@ https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?fm=webp 300w",
 exports[`[ref] fluid, jpg with max width (1200) 1`] = `
 Object {
   "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 300px) 100vw, 300px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=150&h=100&fit=crop 150w,
@@ -401,7 +385,7 @@ https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?fm=webp 300w",
 exports[`[ref] fluid, jpg without params 1`] = `
 Object {
   "aspectRatio": 1.5,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 300px) 100vw, 300px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=150&h=100&fit=crop 150w,
@@ -415,7 +399,7 @@ https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?fm=webp 300w",
 exports[`[ref] fluid, webp with max width (1200) + max height (768) 1`] = `
 Object {
   "aspectRatio": 1.5625,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 1200px) 100vw, 1200px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1200&h=768&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=300&h=192&fit=crop&fm=jpg 300w,
@@ -439,7 +423,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=4240&h=27
 exports[`[ref] fluid, webp with max width (1200) 1`] = `
 Object {
   "aspectRatio": 1.497175141242938,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 1200px) 100vw, 1200px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1200&h=802&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=300&h=200&fit=crop&fm=jpg 300w,
@@ -463,7 +447,7 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp 4240w",
 exports[`[ref] fluid, webp without params 1`] = `
 Object {
   "aspectRatio": 1.497175141242938,
-  "base64": null,
+  "base64": undefined,
   "sizes": "(max-width: 800px) 100vw, 800px",
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=800&h=534&fit=crop&fm=jpg",
   "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=200&h=134&fit=crop&fm=jpg 200w,
@@ -486,7 +470,6 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp 4240w",
 
 exports[`[resolved] fixed, jpg with width (600) + height (300) 1`] = `
 Object {
-  "aspectRatio": 2,
   "base64": "data:image/jpeg;base64,someString",
   "height": 300,
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=600&h=300&fit=crop",
@@ -499,7 +482,6 @@ Object {
 
 exports[`[resolved] fixed, jpg with width (600) 1`] = `
 Object {
-  "aspectRatio": 1.5,
   "base64": "data:image/jpeg;base64,someString",
   "height": 400,
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
@@ -512,7 +494,6 @@ Object {
 
 exports[`[resolved] fixed, jpg without params 1`] = `
 Object {
-  "aspectRatio": 1.5,
   "base64": "data:image/jpeg;base64,someString",
   "height": 267,
   "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg",
@@ -525,7 +506,6 @@ Object {
 
 exports[`[resolved] fixed, webp with width (600) + height (300) 1`] = `
 Object {
-  "aspectRatio": 2,
   "base64": "data:image/webp;base64,someString",
   "height": 300,
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=300&fit=crop&fm=jpg",
@@ -544,7 +524,6 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1800&h=90
 
 exports[`[resolved] fixed, webp with width (600) 1`] = `
 Object {
-  "aspectRatio": 1.497175141242938,
   "base64": "data:image/webp;base64,someString",
   "height": 401,
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=600&h=401&fit=crop&fm=jpg",
@@ -563,7 +542,6 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1800&h=12
 
 exports[`[resolved] fixed, webp without params 1`] = `
 Object {
-  "aspectRatio": 1.497175141242938,
   "base64": "data:image/webp;base64,someString",
   "height": 267,
   "src": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=400&h=267&fit=crop&fm=jpg",


### PR DESCRIPTION
This PR aligns the image fragments we provide with that of gatsby-image:
- Certain properties (`src`, `srcSet` etc) should be set as non-nulls (fixes typescript inference)
- `aspectRatio` should not be returned on fixed images
- `base64` should be `undefined` if not available, not `null`

Fixes #57