### PR TITLE
make env variable consistent across examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module.exports = {
         dataset: `blog`,
         // a token with read permissions is required
         // if you have a private dataset
-        token: process.env.MY_SANITY_TOKEN,
+        token: process.env.SANITY_TOKEN,
 
         // If the Sanity GraphQL API was deployed using `--tag <name>`,
         // use `graphqlTag` to specify the tag name. Defaults to `default`.


### PR DESCRIPTION
This matches the rest of the examples. Small item, but can be a frustrating tripping point for copy-pasters and beginners alike :) 