### PR TITLE
Exclude system documents in listener query

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -185,10 +185,9 @@ export const sourceNodes = async (context: GatsbyContext, pluginConfig: PluginCo
   if (watchMode) {
     reporter.info('[sanity] Watch mode enabled, starting a listener')
     client
-      .listen('*')
+      .listen('*[!(_id in path("_.**"))]')
       .pipe(
         filter((event) => overlayDrafts || !event.documentId.startsWith('drafts.')),
-        filter((event) => !event.documentId.startsWith('_.')),
       )
       .subscribe((event) => handleListenerEvent(event, publishedNodes, context, processingOptions))
   }


### PR DESCRIPTION
Currently we set up a listener for all documents in the dataset and exclude system documents after mutation event is received. With this patch we instead exclude system documents in the query itself, which saves a bit of bandwidth for listeners events we don't care about.