### PR TITLE
Adding types property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gatsby-source-plugin"
   ],
   "main": "index.js",
+  "types": "lib-es5/index.d.ts",
   "scripts": {
     "test": "jest",
     "build": "tsc && tsc -t ES5 --outDir lib-es5",


### PR DESCRIPTION
Supports type resolution when importing into a TypeScript project. Addresses issue #78.