### PR TITLE
Export `ImageFormat` type.

### DIFF
--- a/src/images/getGatsbyImageProps.ts
+++ b/src/images/getGatsbyImageProps.ts
@@ -5,7 +5,7 @@ export const DEFAULT_FIXED_WIDTH = 400
 export const DEFAULT_FLUID_MAX_WIDTH = 800
 export type ImageNode = ImageAsset | ImageObject | ImageRef | string | null | undefined
 
-enum ImageFormat {
+export enum ImageFormat {
   NO_CHANGE = '',
   WEBP = 'webp',
   JPG = 'jpg',

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@ export {
   getFixedGatsbyImage,
   GatsbyFixedImageProps,
   GatsbyFluidImageProps,
+  ImageFormat,
 } from './images/getGatsbyImageProps'
 export {resolveReferences} from './util/resolveReferences'


### PR DESCRIPTION
The `getFixedGatsbyImage` and `getFluidGatsbyImage` `toFormat` argument expects a value from the enum `ImageFormat` this is not exported anywhere thus when using this in TS you will get type error.

![image](https://user-images.githubusercontent.com/8649366/94162868-2edafc00-fe55-11ea-8e27-ebcb4c29afc3.png)


![image](https://user-images.githubusercontent.com/8649366/94162908-3c908180-fe55-11ea-87da-f8fb761cf3eb.png)
