### PR TITLE
Add gatsbyImageData resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - '10'
+  - '12'

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-config-prettier": "^6.14.0",
     "eslint-config-sanity": "^1.150.8",
     "gatsby": "^2.24.87",
-    "gatsby-plugin-image": "^0.7.0",
+    "gatsby-plugin-image": "^1.0.0-next.3",
     "jest": "^26.6.1",
     "prettier": "^2.1.2",
     "react": "^16.14.0",
@@ -73,6 +73,6 @@
   },
   "peerDependencies": {
     "gatsby": "^2.2.0",
-    "gatsby-plugin-image": "^0.7.0"
+    "gatsby-plugin-image": "^1.0.0-next.3 | >=1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "axios": "^0.21.0",
     "debug": "^4.2.0",
     "fs-extra": "^9.0.1",
-    "gatsby-plugin-image": "next",
     "get-stream": "^5.1.0",
     "lodash": "^4.17.20",
     "oneline": "^1.0.2",
@@ -65,12 +64,15 @@
     "eslint-config-prettier": "^6.14.0",
     "eslint-config-sanity": "^1.150.8",
     "gatsby": "^2.24.87",
+    "gatsby-plugin-image": "^0.7.0",
     "jest": "^26.6.1",
     "prettier": "^2.1.2",
+    "react": "^16.14.0",
     "ts-jest": "^26.4.2",
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.2.0"
+    "gatsby": "^2.2.0",
+    "gatsby-plugin-image": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint": "^7.12.0",
     "eslint-config-prettier": "^6.14.0",
     "eslint-config-sanity": "^1.150.8",
-    "gatsby": "^2.24.87",
+    "gatsby": "^3.0.0-next.4",
     "gatsby-plugin-image": "^1.0.0-next.3",
     "jest": "^26.6.1",
     "prettier": "^2.1.2",
@@ -72,7 +72,7 @@
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.2.0",
+    "gatsby": "^3.0.0-next.4 | >=3.0.0",
     "gatsby-plugin-image": "^1.0.0-next.3 | >=1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "axios": "^0.21.0",
     "debug": "^4.2.0",
     "fs-extra": "^9.0.1",
+    "gatsby-plugin-image": "next",
     "get-stream": "^5.1.0",
     "lodash": "^4.17.20",
     "oneline": "^1.0.2",

--- a/src/images/extendImageNode.ts
+++ b/src/images/extendImageNode.ts
@@ -6,6 +6,7 @@ import {
   GraphQLEnumType,
   GraphQLNonNull,
   GraphQLFieldConfig,
+  GraphQLFieldConfigMap,
 } from 'gatsby/graphql'
 import {PluginConfig} from '../gatsby-node'
 import {getCacheKey, CACHE_KEYS} from '../util/cache'
@@ -54,15 +55,13 @@ const ImagePlaceholderType = new GraphQLEnumType({
   },
 })
 
-const extensions = new Map()
+const extensions = new Map<string, GraphQLFieldConfigMap<any, any>>()
 
-export function extendImageNode(
-  config: PluginConfig,
-): {[key: string]: GraphQLFieldConfig<any, any>} {
+export function extendImageNode(config: PluginConfig): GraphQLFieldConfigMap<any, any> {
   const key = getCacheKey(config, CACHE_KEYS.IMAGE_EXTENSIONS)
 
   if (extensions.has(key)) {
-    return extensions.get(key)
+    return extensions.get(key) as GraphQLFieldConfigMap<any, any>
   }
 
   const extension = getExtension(config)
@@ -70,9 +69,9 @@ export function extendImageNode(
   return extension
 }
 
-function getExtension(config: PluginConfig) {
+function getExtension(config: PluginConfig): GraphQLFieldConfigMap<any, any> {
   const location = {projectId: config.projectId, dataset: config.dataset}
-  const fixed = {
+  const fixed: GraphQLFieldConfig<any, any> = {
     type: new GraphQLObjectType({
       name: 'SanityImageFixed',
       fields: {
@@ -101,7 +100,7 @@ function getExtension(config: PluginConfig) {
     resolve: (image: ImageNode, args: FixedArgs) => getFixedGatsbyImage(image, args, location),
   }
 
-  const fluid = {
+  const fluid: GraphQLFieldConfig<any, any> = {
     type: new GraphQLObjectType({
       name: 'SanityImageFluid',
       fields: {
@@ -136,20 +135,22 @@ function getExtension(config: PluginConfig) {
   return {
     fixed,
     fluid,
-    gatsbyImageData: getGatsbyImageFieldConfig(getGatsbyImageData, {
-      placeholder: {
-        type: ImagePlaceholderType,
-        defaultValue: `dominantColor`,
-        description: `
-          Format of generated placeholder image, displayed while the main image loads. 
-          BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
-          DOMINANT_COLOR: a solid color, calculated from the dominant color of the image. 
-          NONE: no placeholder.`,
+    gatsbyImageData: getGatsbyImageFieldConfig(
+      (image: ImageNode, args: FluidArgs) => getGatsbyImageData(image, args, location),
+      {
+        placeholder: {
+          type: ImagePlaceholderType,
+          defaultValue: `dominantColor`,
+          description: `Format of generated placeholder image, displayed while the main image loads. 
+BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
+DOMINANT_COLOR: a solid color, calculated from the dominant color of the image. 
+NONE: no placeholder.`,
+        },
+        fit: {
+          type: ImageFitType,
+          defaultValue: 'fill',
+        },
       },
-      fit: {
-        type: ImageFitType,
-        defaultValue: 'cover',
-      },
-    }),
+    ),
   }
 }

--- a/src/images/extendImageNode.ts
+++ b/src/images/extendImageNode.ts
@@ -6,6 +6,7 @@ import {
   GraphQLEnumType,
   GraphQLNonNull,
   GraphQLFieldConfig,
+  GraphQLJSON,
 } from 'gatsby/graphql'
 import {PluginConfig} from '../gatsby-node'
 import {getCacheKey, CACHE_KEYS} from '../util/cache'
@@ -17,6 +18,8 @@ import {
   FluidArgs,
   DEFAULT_FLUID_MAX_WIDTH,
   DEFAULT_FIXED_WIDTH,
+  getGatsbyImageData,
+  GatsbyImageDataArgs,
 } from './getGatsbyImageProps'
 
 const ImageFormatType = new GraphQLEnumType({
@@ -26,6 +29,37 @@ const ImageFormatType = new GraphQLEnumType({
     JPG: {value: 'jpg'},
     PNG: {value: 'png'},
     WEBP: {value: 'webp'},
+  },
+})
+
+const ImageFitType = new GraphQLEnumType({
+  name: 'SanityImageFit',
+  values: {
+    CLIP: {value: 'clip'},
+    CROP: {value: 'crop'},
+    FILL: {value: 'fill'},
+    FILLMAX: {value: 'fillmax'},
+    MAX: {value: 'max'},
+    SCALE: {value: 'scale'},
+    MIN: {value: 'min'},
+  },
+})
+
+const ImageLayoutType = new GraphQLEnumType({
+  name: `GatsbyImageLayout`,
+  values: {
+    FIXED: {value: `fixed`},
+    FULL_WIDTH: {value: `fullWidth`},
+    CONSTRAINED: {value: `constrained`},
+  },
+})
+
+const ImagePlaceholderType = new GraphQLEnumType({
+  name: `GatsbyImagePlaceholder`,
+  values: {
+    DOMINANT_COLOR: {value: `dominantColor`},
+    BLURRED: {value: `blurred`},
+    NONE: {value: `none`},
   },
 })
 
@@ -108,5 +142,64 @@ function getExtension(config: PluginConfig) {
     resolve: (image: ImageNode, args: FluidArgs) => getFluidGatsbyImage(image, args, location),
   }
 
-  return {fixed, fluid}
+  const gatsbyImageData = {
+    type: new GraphQLNonNull(GraphQLJSON),
+    args: {
+      layout: {
+        type: ImageLayoutType,
+        defaultValue: `constrained`,
+        description: `
+            The layout for the image.
+            FIXED: A static image sized, that does not resize according to the screen width
+            FULL_WIDTH: The image resizes to fit its container. Pass a "sizes" option if it isn't going to be the full width of the screen. 
+            CONSTRAINED: Resizes to fit its container, up to a maximum width, at which point it will remain fixed in size.
+            `,
+      },
+      width: {
+        type: GraphQLInt,
+        description: `
+        The display width of the generated image for layout = FIXED, and the display width of the largest image for layout = CONSTRAINED.  
+        The actual largest image resolution will be this value multiplied by the largest value in outputPixelDensities
+        Ignored if layout = FLUID.
+        `,
+      },
+      height: {
+        type: GraphQLInt,
+        description: `
+        If set, the height of the generated image. If omitted, it is calculated from the supplied width, matching the aspect ratio of the source image.`,
+      },
+      placeholder: {
+        type: ImagePlaceholderType,
+        defaultValue: `dominantColor`,
+        description: `
+            Format of generated placeholder image, displayed while the main image loads. 
+            BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
+            DOMINANT_COLOR: a solid color, calculated from the dominant color of the image. 
+            NONE: no placeholder.`,
+      },
+      sizes: {
+        type: GraphQLString,
+        description: `
+            The "sizes" property, passed to the img tag. This describes the display size of the image. 
+            This does not affect the generated images, but is used by the browser to decide which images to download. You can leave this blank for fixed images, or if the responsive image
+            container will be the full width of the screen. In these cases we will generate an appropriate value.
+        `,
+      },
+      aspectRatio: {
+        type: GraphQLFloat,
+        description: `
+        If set along with width or height, this will set the value of the other dimension to match the provided aspect ratio, cropping the image if needed. 
+        If neither width or height is provided, height will be set based on the intrinsic width of the source image.
+        `,
+      },
+      fit: {
+        type: ImageFitType,
+        defaultValue: 'cover',
+      },
+    },
+    resolve: (image: ImageNode, args: GatsbyImageDataArgs) =>
+      getGatsbyImageData(image, args, location),
+  }
+
+  return {fixed, fluid, gatsbyImageData}
 }

--- a/src/images/extendImageNode.ts
+++ b/src/images/extendImageNode.ts
@@ -6,7 +6,6 @@ import {
   GraphQLEnumType,
   GraphQLNonNull,
   GraphQLFieldConfig,
-  GraphQLJSON,
 } from 'gatsby/graphql'
 import {PluginConfig} from '../gatsby-node'
 import {getCacheKey, CACHE_KEYS} from '../util/cache'
@@ -19,8 +18,9 @@ import {
   DEFAULT_FLUID_MAX_WIDTH,
   DEFAULT_FIXED_WIDTH,
   getGatsbyImageData,
-  GatsbyImageDataArgs,
 } from './getGatsbyImageProps'
+
+import {getGatsbyImageFieldConfig} from 'gatsby-plugin-image/graphql-utils'
 
 const ImageFormatType = new GraphQLEnumType({
   name: 'SanityImageFormat',
@@ -42,15 +42,6 @@ const ImageFitType = new GraphQLEnumType({
     MAX: {value: 'max'},
     SCALE: {value: 'scale'},
     MIN: {value: 'min'},
-  },
-})
-
-const ImageLayoutType = new GraphQLEnumType({
-  name: `GatsbyImageLayout`,
-  values: {
-    FIXED: {value: `fixed`},
-    FULL_WIDTH: {value: `fullWidth`},
-    CONSTRAINED: {value: `constrained`},
   },
 })
 
@@ -142,64 +133,23 @@ function getExtension(config: PluginConfig) {
     resolve: (image: ImageNode, args: FluidArgs) => getFluidGatsbyImage(image, args, location),
   }
 
-  const gatsbyImageData = {
-    type: new GraphQLNonNull(GraphQLJSON),
-    args: {
-      layout: {
-        type: ImageLayoutType,
-        defaultValue: `constrained`,
-        description: `
-            The layout for the image.
-            FIXED: A static image sized, that does not resize according to the screen width
-            FULL_WIDTH: The image resizes to fit its container. Pass a "sizes" option if it isn't going to be the full width of the screen. 
-            CONSTRAINED: Resizes to fit its container, up to a maximum width, at which point it will remain fixed in size.
-            `,
-      },
-      width: {
-        type: GraphQLInt,
-        description: `
-        The display width of the generated image for layout = FIXED, and the display width of the largest image for layout = CONSTRAINED.  
-        The actual largest image resolution will be this value multiplied by the largest value in outputPixelDensities
-        Ignored if layout = FLUID.
-        `,
-      },
-      height: {
-        type: GraphQLInt,
-        description: `
-        If set, the height of the generated image. If omitted, it is calculated from the supplied width, matching the aspect ratio of the source image.`,
-      },
+  return {
+    fixed,
+    fluid,
+    gatsbyImageData: getGatsbyImageFieldConfig(getGatsbyImageData, {
       placeholder: {
         type: ImagePlaceholderType,
         defaultValue: `dominantColor`,
         description: `
-            Format of generated placeholder image, displayed while the main image loads. 
-            BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
-            DOMINANT_COLOR: a solid color, calculated from the dominant color of the image. 
-            NONE: no placeholder.`,
-      },
-      sizes: {
-        type: GraphQLString,
-        description: `
-            The "sizes" property, passed to the img tag. This describes the display size of the image. 
-            This does not affect the generated images, but is used by the browser to decide which images to download. You can leave this blank for fixed images, or if the responsive image
-            container will be the full width of the screen. In these cases we will generate an appropriate value.
-        `,
-      },
-      aspectRatio: {
-        type: GraphQLFloat,
-        description: `
-        If set along with width or height, this will set the value of the other dimension to match the provided aspect ratio, cropping the image if needed. 
-        If neither width or height is provided, height will be set based on the intrinsic width of the source image.
-        `,
+          Format of generated placeholder image, displayed while the main image loads. 
+          BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
+          DOMINANT_COLOR: a solid color, calculated from the dominant color of the image. 
+          NONE: no placeholder.`,
       },
       fit: {
         type: ImageFitType,
         defaultValue: 'cover',
       },
-    },
-    resolve: (image: ImageNode, args: GatsbyImageDataArgs) =>
-      getGatsbyImageData(image, args, location),
+    }),
   }
-
-  return {fixed, fluid, gatsbyImageData}
 }

--- a/src/images/getGatsbyImageProps.ts
+++ b/src/images/getGatsbyImageProps.ts
@@ -59,20 +59,20 @@ export type GatsbyFluidImageProps = {
 }
 
 type ImagePalette = {
-  darkMuted: ImagePaletteSwatch
-  lightVibrant: ImagePaletteSwatch
-  darkVibrant: ImagePaletteSwatch
-  vibrant: ImagePaletteSwatch
-  dominant: ImagePaletteSwatch
-  lightMuted: ImagePaletteSwatch
-  muted: ImagePaletteSwatch
+  darkMuted?: ImagePaletteSwatch
+  lightVibrant?: ImagePaletteSwatch
+  darkVibrant?: ImagePaletteSwatch
+  vibrant?: ImagePaletteSwatch
+  dominant?: ImagePaletteSwatch
+  lightMuted?: ImagePaletteSwatch
+  muted?: ImagePaletteSwatch
 }
 
 type ImagePaletteSwatch = {
-  background: string
-  foreground: string
-  population: number
-  title: string
+  background?: string
+  foreground?: string
+  population?: number
+  title?: string
 }
 
 type ImageDimensions = {

--- a/src/images/getGatsbyImageProps.ts
+++ b/src/images/getGatsbyImageProps.ts
@@ -368,7 +368,7 @@ const generateImageSource: IGatsbyImageHelperArgs['generateImageSource'] = (
   options,
 ) => {
   const {builder} = options as {builder: ImageUrlBuilder}
-  const src = builder.width(width).height(height).url() as string
+  const src = builder.width(width).height(height).auto('format').url() as string
   return {width, height, format: 'auto', src}
 }
 

--- a/src/images/getGatsbyImageProps.ts
+++ b/src/images/getGatsbyImageProps.ts
@@ -82,7 +82,7 @@ type ImageDimensions = {
 }
 
 type ImageMetadata = {
-  palette: ImagePalette
+  palette?: ImagePalette
   dimensions: ImageDimensions
   lqip?: string
 }
@@ -419,7 +419,7 @@ export function getGatsbyImageData(
   let placeholderDataURI: string | undefined
 
   if (args.placeholder === `dominantColor`) {
-    imageProps.backgroundColor = imageStub.metadata.palette.dominant.background
+    imageProps.backgroundColor = imageStub.metadata.palette?.dominant?.background
   }
 
   if (args.placeholder === `blurred`) {

--- a/src/util/handleListenerEvent.ts
+++ b/src/util/handleListenerEvent.ts
@@ -41,7 +41,7 @@ export function handleListenerEvent(
     } else if (current) {
       // Deleted a node that we currently have, delete it
       debug('Published document deleted, remove')
-      deleteNode({node: current})
+      deleteNode(current)
     }
 
     return
@@ -59,13 +59,13 @@ export function handleListenerEvent(
       createNode(published)
     } else if (touchedIsDraft && !published && current) {
       debug('Draft deleted, no published version exist, delete node')
-      deleteNode({node: current})
+      deleteNode(current)
     } else if (!touchedIsDraft && currentIsDraft && published) {
       debug('Published version deleted, but we have draft, remove published from working set')
       publishedNodes.delete(event.documentId)
     } else if (!touchedIsDraft && !currentIsDraft && current) {
       debug('Published version deleted, we have no draft, remove node entirely')
-      deleteNode({node: current})
+      deleteNode(current)
       publishedNodes.delete(event.documentId)
     }
   } else {

--- a/src/util/handleWebhookEvent.ts
+++ b/src/util/handleWebhookEvent.ts
@@ -65,7 +65,7 @@ function handleDeletedDocuments(context: SourceNodesArgs, ids: string[]) {
     .filter((node): node is SanityNode => typeof node !== 'undefined')
     .reduce((count, node) => {
       debug('Deleted document with ID %s', node._id)
-      deleteNode({node})
+      deleteNode(node)
       return count + 1
     }, 0)
 }

--- a/test/__snapshots__/getGatsbyImageProps.test.ts.snap
+++ b/test/__snapshots__/getGatsbyImageProps.test.ts.snap
@@ -264,6 +264,133 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp 4240w",
 }
 `;
 
+exports[`[id] gatsbyImageData constrained jpg with width (600) 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 400,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "(min-width: 300px) 300px, 100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "constrained",
+  "width": 600,
+}
+`;
+
+exports[`[id] gatsbyImageData fixed jpg 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 200,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "300px",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "fixed",
+  "width": 300,
+}
+`;
+
+exports[`[id] gatsbyImageData fullWidth jpg 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 0.6666666666666666,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "fullWidth",
+  "width": 1,
+}
+`;
+
+exports[`[id] gatsbyImageData jpeg with width/height (300x300) > original size, same aspect 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "images": Object {
+    "fallback": Object {
+      "sizes": undefined,
+      "src": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?w=70&h=70&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?w=70&h=70&auto=format 70w",
+    },
+    "sources": Array [],
+  },
+  "layout": undefined,
+}
+`;
+
+exports[`[id] gatsbyImageData jpeg with width/height (320x240) > original size, different aspect 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "images": Object {
+    "fallback": Object {
+      "sizes": undefined,
+      "src": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?rect=0,8,70,53&w=70&h=53&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?rect=0,8,70,53&w=70&h=53&auto=format 70w",
+    },
+    "sources": Array [],
+  },
+  "layout": undefined,
+}
+`;
+
+exports[`[id] gatsbyImageData jpg with width (600) + height (300) 1`] = `
+Object {
+  "base64": undefined,
+  "height": 300,
+  "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=600&h=300&fit=crop",
+  "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=600&h=300&fit=crop 1x",
+  "srcSetWebp": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=600&h=300&fit=crop&fm=webp 1x",
+  "srcWebp": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=600&h=300&fit=crop&fm=webp",
+  "width": 600,
+}
+`;
+
+exports[`[id] gatsbyImageData jpg without params 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 200,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "(min-width: 300px) 300px, 100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "constrained",
+  "width": 300,
+}
+`;
+
+exports[`[id] gatsbyImageData, jpeg with width (300) > original size 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 300,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "(min-width: 70px) 70px, 100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?w=70&h=70&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/bf1942-70x70.jpg?w=70&h=70&auto=format 70w",
+    },
+    "sources": Array [],
+  },
+  "layout": "constrained",
+  "width": 300,
+}
+`;
+
 exports[`[ref] fixed, jpg with width (600) + height (300) 1`] = `
 Object {
   "base64": undefined,
@@ -468,6 +595,74 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp 4240w",
 }
 `;
 
+exports[`[ref] gatabyImageData jpg without params 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 200,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "(min-width: 300px) 300px, 100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "constrained",
+  "width": 300,
+}
+`;
+
+exports[`[ref] gatsbyImageData constrained jpg with width (600) 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 400,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "(min-width: 300px) 300px, 100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "constrained",
+  "width": 600,
+}
+`;
+
+exports[`[ref] gatsbyImageData fixed jpg 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 200,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "300px",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "fixed",
+  "width": 300,
+}
+`;
+
+exports[`[ref] gatsbyImageData fullWidth jpg 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 0.6666666666666666,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "fullWidth",
+  "width": 1,
+}
+`;
+
 exports[`[resolved] fixed, jpg with width (600) + height (300) 1`] = `
 Object {
   "base64": "data:image/jpeg;base64,someString",
@@ -669,5 +864,132 @@ https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1600&h=10
 https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=2400&h=1603&fit=crop 2400w,
 https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp 4240w",
   "srcWebp": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=800&h=534&fit=crop",
+}
+`;
+
+exports[`[resolved] gatabyImageData jpg without params 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 200,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "(min-width: 300px) 300px, 100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "constrained",
+  "width": 300,
+}
+`;
+
+exports[`[resolved] gatsbyImageData constrained jpg with width (600) 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 400,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "(min-width: 300px) 300px, 100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "constrained",
+  "width": 600,
+}
+`;
+
+exports[`[resolved] gatsbyImageData fixed jpg 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 200,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "300px",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "fixed",
+  "width": 300,
+}
+`;
+
+exports[`[resolved] gatsbyImageData fullWidth jpg 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 0.6666666666666666,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "fullWidth",
+  "width": 1,
+}
+`;
+
+exports[`[resolved] gatsbyImageData webp fullWidth 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 0.6679245283018868,
+  "images": Object {
+    "sources": Array [
+      Object {
+        "sizes": "100vw",
+        "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=3,0,4235,2832&w=320&h=214&auto=format 320w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=1,0,4238,2832&w=654&h=437&auto=format 654w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=768&h=513&auto=format 768w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1024&h=684&auto=format 1024w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=0,0,4240,2831&w=1366&h=912&auto=format 1366w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=1,0,4239,2832&w=1600&h=1069&auto=format 1600w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=0,0,4240,2831&w=1920&h=1282&auto=format 1920w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=2048&h=1368&auto=format 2048w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=2560&h=1710&auto=format 2560w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=0,0,4239,2832&w=3440&h=2298&auto=format 3440w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=3840&h=2565&auto=format 3840w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=4096&h=2736&auto=format 4096w",
+        "type": "image/webp",
+      },
+    ],
+  },
+  "layout": "fullWidth",
+  "width": 1,
+}
+`;
+
+exports[`[resolved] gatsbyImageData webp without params 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 2832,
+  "images": Object {
+    "sources": Array [
+      Object {
+        "sizes": "(min-width: 4240px) 4240px, 100vw",
+        "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=3,0,4235,2832&w=320&h=214&auto=format 320w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=1,0,4238,2832&w=654&h=437&auto=format 654w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=768&h=513&auto=format 768w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1024&h=684&auto=format 1024w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=0,0,4240,2831&w=1366&h=912&auto=format 1366w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=1,0,4239,2832&w=1600&h=1069&auto=format 1600w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=0,0,4240,2831&w=1920&h=1282&auto=format 1920w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=2048&h=1368&auto=format 2048w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=2560&h=1710&auto=format 2560w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=0,0,4239,2832&w=3440&h=2298&auto=format 3440w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=3840&h=2565&auto=format 3840w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=4096&h=2736&auto=format 4096w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=4240&h=2832&auto=format 4240w",
+        "type": "image/webp",
+      },
+    ],
+  },
+  "layout": "constrained",
+  "width": 4240,
 }
 `;

--- a/test/__snapshots__/getGatsbyImageProps.test.ts.snap
+++ b/test/__snapshots__/getGatsbyImageProps.test.ts.snap
@@ -884,6 +884,26 @@ Object {
 }
 `;
 
+exports[`[resolved] gatsbyImageData blurred placeholder 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 200,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "(min-width: 300px) 300px, 100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "constrained",
+  "placeholder": Object {
+    "fallback": "data:image/jpeg;base64,someString",
+  },
+  "width": 300,
+}
+`;
+
 exports[`[resolved] gatsbyImageData constrained jpg with width (600) 1`] = `
 Object {
   "backgroundColor": undefined,
@@ -898,6 +918,23 @@ Object {
   },
   "layout": "constrained",
   "width": 600,
+}
+`;
+
+exports[`[resolved] gatsbyImageData dominantColor placeholder 1`] = `
+Object {
+  "backgroundColor": "rebeccapurple",
+  "height": 200,
+  "images": Object {
+    "fallback": Object {
+      "sizes": "(min-width: 300px) 300px, 100vw",
+      "src": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format",
+      "srcSet": "https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg?w=300&h=200&auto=format 300w",
+    },
+    "sources": Array [],
+  },
+  "layout": "constrained",
+  "width": 300,
 }
 `;
 
@@ -932,6 +969,36 @@ Object {
   },
   "layout": "fullWidth",
   "width": 1,
+}
+`;
+
+exports[`[resolved] gatsbyImageData webp dominant color 1`] = `
+Object {
+  "backgroundColor": undefined,
+  "height": 2832,
+  "images": Object {
+    "sources": Array [
+      Object {
+        "sizes": "(min-width: 4240px) 4240px, 100vw",
+        "srcSet": "https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=3,0,4235,2832&w=320&h=214&auto=format 320w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=1,0,4238,2832&w=654&h=437&auto=format 654w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=768&h=513&auto=format 768w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=1024&h=684&auto=format 1024w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=0,0,4240,2831&w=1366&h=912&auto=format 1366w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=1,0,4239,2832&w=1600&h=1069&auto=format 1600w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=0,0,4240,2831&w=1920&h=1282&auto=format 1920w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=2048&h=1368&auto=format 2048w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=2560&h=1710&auto=format 2560w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?rect=0,0,4239,2832&w=3440&h=2298&auto=format 3440w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=3840&h=2565&auto=format 3840w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=4096&h=2736&auto=format 4096w,
+https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp?w=4240&h=2832&auto=format 4240w",
+        "type": "image/webp",
+      },
+    ],
+  },
+  "layout": "constrained",
+  "width": 4240,
 }
 `;
 

--- a/test/getGatsbyImageProps.test.ts
+++ b/test/getGatsbyImageProps.test.ts
@@ -1,4 +1,8 @@
-import {getFixedGatsbyImage, getFluidGatsbyImage} from '../src/images/getGatsbyImageProps'
+import {
+  getFixedGatsbyImage,
+  getFluidGatsbyImage,
+  getGatsbyImageData,
+} from '../src/images/getGatsbyImageProps'
 
 // Smallish image
 const jpegId = 'image-abc123-300x200-jpg'
@@ -49,12 +53,28 @@ test('[resolved] fixed, jpg without params', () => {
   expect(getFixedGatsbyImage(jpegResolved, {}, location)).toMatchSnapshot()
 })
 
+test('[resolved] gatabyImageData jpg without params', () => {
+  expect(getGatsbyImageData(jpegResolved, {}, location)).toMatchSnapshot()
+})
+
 test('[resolved] fluid, jpg without params', () => {
   expect(getFluidGatsbyImage(jpegResolved, {}, location)).toMatchSnapshot()
 })
 
+test('[resolved] gatsbyImageData fullWidth jpg', () => {
+  expect(getGatsbyImageData(jpegResolved, {layout: 'fullWidth'}, location)).toMatchSnapshot()
+})
+
+test('[resolved] gatsbyImageData fixed jpg', () => {
+  expect(getGatsbyImageData(jpegResolved, {layout: 'fixed'}, location)).toMatchSnapshot()
+})
+
 test('[resolved] fixed, jpg with width (600)', () => {
   expect(getFixedGatsbyImage(jpegResolved, {width: 600}, location)).toMatchSnapshot()
+})
+
+test('[resolved] gatsbyImageData constrained jpg with width (600)', () => {
+  expect(getGatsbyImageData(jpegResolved, {width: 600}, location)).toMatchSnapshot()
 })
 
 test('[resolved] fluid, jpg with max width (1200)', () => {
@@ -74,13 +94,28 @@ test('[resolved] fluid, jpg with max width (1200) + max height (768)', () => {
 test('[ref] fixed, jpg without params', () => {
   expect(getFixedGatsbyImage(jpegRef, {}, location)).toMatchSnapshot()
 })
+test('[ref] gatabyImageData jpg without params', () => {
+  expect(getGatsbyImageData(jpegRef, {}, location)).toMatchSnapshot()
+})
 
 test('[ref] fluid, jpg without params', () => {
   expect(getFluidGatsbyImage(jpegRef, {}, location)).toMatchSnapshot()
 })
 
+test('[ref] gatsbyImageData fullWidth jpg', () => {
+  expect(getGatsbyImageData(jpegRef, {layout: 'fullWidth'}, location)).toMatchSnapshot()
+})
+
+test('[ref] gatsbyImageData fixed jpg', () => {
+  expect(getGatsbyImageData(jpegRef, {layout: 'fixed'}, location)).toMatchSnapshot()
+})
+
 test('[ref] fixed, jpg with width (600)', () => {
   expect(getFixedGatsbyImage(jpegRef, {width: 600}, location)).toMatchSnapshot()
+})
+
+test('[ref] gatsbyImageData constrained jpg with width (600)', () => {
+  expect(getGatsbyImageData(jpegRef, {width: 600}, location)).toMatchSnapshot()
 })
 
 test('[ref] fluid, jpg with max width (1200)', () => {
@@ -99,12 +134,28 @@ test('[id] fixed, jpg without params', () => {
   expect(getFixedGatsbyImage(jpegId, {}, location)).toMatchSnapshot()
 })
 
+test('[id] gatsbyImageData jpg without params', () => {
+  expect(getGatsbyImageData(jpegId, {}, location)).toMatchSnapshot()
+})
+
 test('[id] fluid, jpg without params', () => {
   expect(getFluidGatsbyImage(jpegId, {}, location)).toMatchSnapshot()
 })
 
+test('[id] gatsbyImageData fullWidth jpg', () => {
+  expect(getGatsbyImageData(jpegId, {layout: 'fullWidth'}, location)).toMatchSnapshot()
+})
+
+test('[id] gatsbyImageData fixed jpg', () => {
+  expect(getGatsbyImageData(jpegId, {layout: 'fixed'}, location)).toMatchSnapshot()
+})
+
 test('[id] fixed, jpg with width (600)', () => {
   expect(getFixedGatsbyImage(jpegId, {width: 600}, location)).toMatchSnapshot()
+})
+
+test('[id] gatsbyImageData constrained jpg with width (600)', () => {
+  expect(getGatsbyImageData(jpegId, {width: 600}, location)).toMatchSnapshot()
 })
 
 test('[id] fluid, jpg with max width (1200)', () => {
@@ -112,6 +163,10 @@ test('[id] fluid, jpg with max width (1200)', () => {
 })
 
 test('[id] fixed, jpg with width (600) + height (300)', () => {
+  expect(getFixedGatsbyImage(jpegId, {width: 600, height: 300}, location)).toMatchSnapshot()
+})
+
+test('[id] gatsbyImageData jpg with width (600) + height (300)', () => {
   expect(getFixedGatsbyImage(jpegId, {width: 600, height: 300}, location)).toMatchSnapshot()
 })
 
@@ -124,8 +179,16 @@ test('[resolved] fixed, webp without params', () => {
   expect(getFixedGatsbyImage(webpResolved, {}, location)).toMatchSnapshot()
 })
 
+test('[resolved] gatsbyImageData webp without params', () => {
+  expect(getGatsbyImageData(webpResolved, {}, location)).toMatchSnapshot()
+})
+
 test('[resolved] fluid, webp without params', () => {
   expect(getFluidGatsbyImage(webpResolved, {}, location)).toMatchSnapshot()
+})
+
+test('[resolved] gatsbyImageData webp fullWidth', () => {
+  expect(getGatsbyImageData(webpResolved, {layout: 'fullWidth'}, location)).toMatchSnapshot()
 })
 
 test('[resolved] fixed, webp with width (600)', () => {
@@ -199,14 +262,24 @@ test('[id] fluid, jpeg with max width (300) > original size', () => {
   expect(getFluidGatsbyImage(smallId, {maxWidth: 300}, location)).toMatchSnapshot()
 })
 
+test('[id] gatsbyImageData, jpeg with width (300) > original size', () => {
+  expect(getGatsbyImageData(smallId, {width: 300}, location)).toMatchSnapshot()
+})
+
 // No upscaling for fixed with same aspect ratio
 test('[id] fixed, jpeg with width/height (300x300) > original size, same aspect', () => {
   expect(getFixedGatsbyImage(smallId, {width: 300, height: 300}, location)).toMatchSnapshot()
+})
+test('[id] gatsbyImageData jpeg with width/height (300x300) > original size, same aspect', () => {
+  expect(getGatsbyImageData(smallId, {width: 300, height: 300}, location)).toMatchSnapshot()
 })
 
 // Upscale for fixed with different aspect ratio
 test('[id] fixed, jpeg with width/height (320x240) > original size, different aspect', () => {
   expect(getFixedGatsbyImage(smallId, {width: 320, height: 240}, location)).toMatchSnapshot()
+})
+test('[id] gatsbyImageData jpeg with width/height (320x240) > original size, different aspect', () => {
+  expect(getGatsbyImageData(smallId, {width: 320, height: 240}, location)).toMatchSnapshot()
 })
 
 // No width/height parameters if size matches original

--- a/test/getGatsbyImageProps.test.ts
+++ b/test/getGatsbyImageProps.test.ts
@@ -2,12 +2,13 @@ import {
   getFixedGatsbyImage,
   getFluidGatsbyImage,
   getGatsbyImageData,
+  ImageNode,
 } from '../src/images/getGatsbyImageProps'
 
 // Smallish image
 const jpegId = 'image-abc123-300x200-jpg'
 const jpegRef = {_ref: 'image-abc123-300x200-jpg'}
-const jpegResolved = {
+const jpegResolved: ImageNode = {
   _id: 'image-abc123-300x200-jpg',
   url: 'https://cdn.sanity.io/images/projectId/dataset/abc123-300x200.jpg',
   assetId: 'abc123',
@@ -19,13 +20,18 @@ const jpegResolved = {
       height: 200,
       aspectRatio: 300 / 200,
     },
+    palette: {
+      dominant: {
+        background: 'rebeccapurple',
+      },
+    },
   },
 }
 
 // Largeish image
 const webpId = 'image-def456-4240x2832-webp'
 const webpRef = {_ref: 'image-def456-4240x2832-webp'}
-const webpResolved = {
+const webpResolved: ImageNode = {
   _id: 'image-def456-4240x2832-webp',
   url: 'https://cdn.sanity.io/images/projectId/dataset/def456-4240x2832.webp',
   assetId: 'def456',
@@ -36,6 +42,11 @@ const webpResolved = {
       width: 4240,
       height: 2832,
       aspectRatio: 4240 / 2832,
+    },
+    palette: {
+      dominant: {
+        background: 'papayawhip',
+      },
     },
   },
 }
@@ -67,6 +78,16 @@ test('[resolved] gatsbyImageData fullWidth jpg', () => {
 
 test('[resolved] gatsbyImageData fixed jpg', () => {
   expect(getGatsbyImageData(jpegResolved, {layout: 'fixed'}, location)).toMatchSnapshot()
+})
+
+test('[resolved] gatsbyImageData blurred placeholder', () => {
+  expect(getGatsbyImageData(jpegResolved, {placeholder: 'blurred'}, location)).toMatchSnapshot()
+})
+
+test('[resolved] gatsbyImageData dominantColor placeholder', () => {
+  expect(
+    getGatsbyImageData(jpegResolved, {placeholder: 'dominantColor'}, location),
+  ).toMatchSnapshot()
 })
 
 test('[resolved] fixed, jpg with width (600)', () => {
@@ -180,6 +201,10 @@ test('[resolved] fixed, webp without params', () => {
 })
 
 test('[resolved] gatsbyImageData webp without params', () => {
+  expect(getGatsbyImageData(webpResolved, {}, location)).toMatchSnapshot()
+})
+
+test('[resolved] gatsbyImageData webp dominant color', () => {
   expect(getGatsbyImageData(webpResolved, {}, location)).toMatchSnapshot()
 })
 


### PR DESCRIPTION
Hello!
This PR adds initial support for the beta Gatsby Image plugin. This plugin includes a new, higher-performance image component that gives better Lighthouse scores, and a simpler GraphQL API. [See more information here](https://gatsbyjs.com/docs/how-to/images-and-media/using-gatsby-plugin-image). As part of the image plugin, we have added a toolkit to help add support to source plugins. I have used this to add basic support for the new resolver. See details here: https://github.com/gatsbyjs/gatsby/discussions/28241

The new plugin also now has support for runtime dynamic images with a new `useGatsbyImage` hook. You could create a `SanityImage` component that takes an image node and the image options as props, rather than through GraphQL. I'd love to work with you to show how this could be done.

For the moment, while the image plugin is in beta, we should not be documenting this as the preferred method, but by the time we go to GA next month we'd like to try and start moving starters and examples over to the new plugin. We have a codemod to help users with migration, and there is a possibility to add support for migrating Sanity sites too.

I'd love some feedback on this PR, and whether you like the approach I've taken.
