### PR TITLE
chore: restore gatsbyImageData on image nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,10 @@ import {GatsbyImage} from 'gatsby-plugin-image'
 const sanityConfig = {projectId: 'abc123', dataset: 'blog'}
 
 const Person = ({data}) => {
-  const imageData = getGatsbyImageData(data.sanityPerson.profileImage.asset, {maxWidth: 700}, sanityConfig)
   return (
     <article>
       <h2>{data.sanityPerson.name}</h2>
-      <GatsbyImage image={imageData}/>
+      <GatsbyImage image={data.sanityPerson.profileImage.asset.gatsbyImageData}/>
     </article>
   )
 }
@@ -136,14 +135,16 @@ export const query = graphql`
     sanityPerson {
       name
       profileImage {
-        asset
+        asset {
+          gatsbyImageData(fit: FILLMAX, placeholder: BLURRED)
+        }
       }
     }
   }
 `
 ```
 
-### Usage outside of GraphQL
+### Using images outside of GraphQL
 
 If you are using the raw fields, or simply have an image asset ID you would like to use gatsby-plugin-image for, you can import and call the utility function `getGatsbyImageData`
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -1,5 +1,6 @@
 import {copy} from 'fs-extra'
 import {bufferTime, filter, map, tap} from 'rxjs/operators'
+import {GraphQLFieldConfig} from 'gatsby/graphql'
 import gatsbyPkg from 'gatsby/package.json'
 import SanityClient from '@sanity/client'
 import {
@@ -9,6 +10,7 @@ import {
   ParentSpanPluginArgs,
   PluginOptions,
   Reporter,
+  SetFieldsOnGraphQLNodeTypeArgs,
   SourceNodesArgs,
 } from 'gatsby'
 import {SanityDocument, SanityWebhookBody} from './types/sanity'
@@ -28,6 +30,7 @@ import {
   SANITY_ERROR_CODE_MAP,
   SANITY_ERROR_CODE_MESSAGES,
 } from './util/errors'
+import {extendImageNode} from './images/extendImageNode'
 import {rewriteGraphQLSchema} from './util/rewriteGraphQLSchema'
 import {getGraphQLResolverMap} from './util/getGraphQLResolverMap'
 import {prefixId, unprefixId} from './util/documentIds'
@@ -332,6 +335,19 @@ export const onPreExtractQueries: GatsbyNode['onPreExtractQueries'] = async (
       `${program.directory}/.cache/fragments/sanity-image-fragments.js`,
     )
   }
+}
+
+export const setFieldsOnGraphQLNodeType: GatsbyNode['setFieldsOnGraphQLNodeType'] = async (
+  context: SetFieldsOnGraphQLNodeTypeArgs,
+  pluginConfig: PluginConfig,
+) => {
+  const {type} = context
+  let fields: {[key: string]: GraphQLFieldConfig<any, any>} = {}
+  if (type.name === 'SanityImageAsset') {
+    fields = {...fields, ...extendImageNode(pluginConfig)}
+  }
+
+  return fields
 }
 
 function validateConfig(config: Partial<PluginConfig>, reporter: Reporter): config is PluginConfig {

--- a/src/images/extendImageNode.ts
+++ b/src/images/extendImageNode.ts
@@ -1,0 +1,65 @@
+import {GraphQLEnumType, GraphQLFieldConfigMap} from 'gatsby/graphql'
+import {PluginConfig} from '../gatsby-node'
+import {getCacheKey, CACHE_KEYS} from '../util/cache'
+import {ImageNode, ImageArgs, getGatsbyImageData} from './getGatsbyImageProps'
+
+import {getGatsbyImageFieldConfig} from 'gatsby-plugin-image/graphql-utils'
+
+const ImageFitType = new GraphQLEnumType({
+  name: 'SanityImageFit',
+  values: {
+    CLIP: {value: 'clip'},
+    CROP: {value: 'crop'},
+    FILL: {value: 'fill'},
+    FILLMAX: {value: 'fillmax'},
+    MAX: {value: 'max'},
+    SCALE: {value: 'scale'},
+    MIN: {value: 'min'},
+  },
+})
+
+const ImagePlaceholderType = new GraphQLEnumType({
+  name: `SanityGatsbyImagePlaceholder`,
+  values: {
+    DOMINANT_COLOR: {value: `dominantColor`},
+    BLURRED: {value: `blurred`},
+    NONE: {value: `none`},
+  },
+})
+
+const extensions = new Map<string, GraphQLFieldConfigMap<any, any>>()
+
+export function extendImageNode(config: PluginConfig): GraphQLFieldConfigMap<any, any> {
+  const key = getCacheKey(config, CACHE_KEYS.IMAGE_EXTENSIONS)
+
+  if (extensions.has(key)) {
+    return extensions.get(key) as GraphQLFieldConfigMap<any, any>
+  }
+
+  const extension = getExtension(config)
+  extensions.set(key, extension)
+  return extension
+}
+
+function getExtension(config: PluginConfig): GraphQLFieldConfigMap<any, any> {
+  const location = {projectId: config.projectId, dataset: config.dataset}
+  return {
+    gatsbyImageData: getGatsbyImageFieldConfig(
+      (image: ImageNode, args: ImageArgs) => getGatsbyImageData(image, args, location),
+      {
+        placeholder: {
+          type: ImagePlaceholderType,
+          defaultValue: `dominantColor`,
+          description: `Format of generated placeholder image, displayed while the main image loads.
+BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
+DOMINANT_COLOR: a solid color, calculated from the dominant color of the image.
+NONE: no placeholder.`,
+        },
+        fit: {
+          type: ImageFitType,
+          defaultValue: 'fill',
+        },
+      },
+    ),
+  }
+}

--- a/src/images/getGatsbyImageProps.ts
+++ b/src/images/getGatsbyImageProps.ts
@@ -4,8 +4,7 @@ import {
   IGatsbyImageHelperArgs,
   Layout,
 } from 'gatsby-plugin-image'
-export const DEFAULT_FIXED_WIDTH = 400
-export const DEFAULT_FLUID_MAX_WIDTH = 800
+
 export type ImageNode = ImageAsset | ImageObject | ImageRef | string | null | undefined
 import imageUrlBuilder from '@sanity/image-url'
 import {ImageUrlBuilder} from '@sanity/image-url/lib/types/builder'
@@ -31,7 +30,6 @@ export enum ImageFormat {
   JPG = 'jpg',
   PNG = 'png',
 }
-
 
 type ImagePalette = {
   darkMuted?: ImagePaletteSwatch
@@ -81,16 +79,10 @@ type ImageObject = {
   asset: ImageRef | ImageAsset
 }
 
-export type FluidArgs = {
+export type ImageArgs = {
   maxWidth?: number
   maxHeight?: number
   sizes?: string
-  toFormat?: ImageFormat
-}
-
-export type FixedArgs = {
-  width?: number
-  height?: number
   toFormat?: ImageFormat
 }
 


### PR DESCRIPTION
This partially reverts commit d7ca4624034e43599b51d1bb5008c56707ed4f47, bringing back the gatsbyImageData node and updates readme with improved code examples