### PR TITLE
fix: Set more specific peer deps + engines update

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     }
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.13.0"
   },
   "repository": "https://github.com/sanity-io/gatsby-source-sanity",
   "homepage": "https://github.com/sanity-io/gatsby-source-sanity#readme",
@@ -72,7 +72,7 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "gatsby": ">=3.0.0",
-    "gatsby-plugin-image": ">=1.0.0"
+    "gatsby": "^3.0.0",
+    "gatsby-plugin-image": "^1.0.0"
   }
 }


### PR DESCRIPTION
Hello, Gatsby maintainer here 👋 

While looking at the plugin I noticed that the `peerDependency` on `gatsby` is set incorrectly. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

At the moment you say that _any_ version (v4, v5, v6, etc.) will work with this even when in between we'd introduce breaking changes.

Making it more explicit is the safer choice (in the future you'll be able to mark breaking changes with explicit version ranges) and will allow us to display the plugin as compatible to versions X, Y, Z.

I've also updated the Node engines field as v3 requires at least 12.13.0

Thanks!
