### PR TITLE
fix drafts handle in getAllDocuments

### DIFF
--- a/src/util/getAllDocuments.ts
+++ b/src/util/getAllDocuments.ts
@@ -15,7 +15,7 @@ export async function getAllDocuments(
   return pumpify.obj(
     await getDocumentStream(url, token),
     split(JSON.parse),
-    options.includeDrafts ? removeDrafts() : through.obj(),
+    options.includeDrafts ? through.obj() : removeDrafts(),
     removeSystemDocuments(),
     rejectOnApiError(),
   )


### PR DESCRIPTION
Since v7 the `overlayDrafts` option is not working anymore.
The issue seems to be a wrong check in `getAllDocuments` that removes the drafts when they should be included