### PR TITLE
feat: configurable watch buffer timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Explore http://localhost:8000/\_\_\_graphql after running `gatsby develop` to un
 | graphqlTag    | string  | `default` | If the Sanity GraphQL API was deployed using `--tag <name>`, use this to specify the tag name.                                                                     |
 | overlayDrafts | boolean | `false`   | Set to `true` in order for drafts to replace their published version. By default, drafts will be skipped.                                                          |
 | watchMode     | boolean | `false`   | Set to `true` to keep a listener open and update with the latest changes in realtime. If you add a `token` you will get all content updates down to each keypress. |
+| watchModeBuffer     | number | `150`   | How many milliseconds to wait on watchMode changes before applying them to Gatsby's GraphQL layer. Introduced in 7.2.0. |
 
 ## Preview of unpublished content
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-sanity",
   "description": "Gatsby source plugin for building websites using Sanity.io as a backend.",
-  "version": "7.2.0-next.0",
+  "version": "7.2.0",
   "author": "Sanity.io <hello@sanity.io>",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-sanity",
   "description": "Gatsby source plugin for building websites using Sanity.io as a backend.",
-  "version": "7.1.0",
+  "version": "7.2.0-next.0",
   "author": "Sanity.io <hello@sanity.io>",
   "contributors": [
     {

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -59,12 +59,14 @@ export interface PluginConfig extends PluginOptions {
   graphqlTag: string
   overlayDrafts?: boolean
   watchMode?: boolean
+  watchModeBuffer?: number
 }
 
 const defaultConfig = {
   version: '1',
   overlayDrafts: false,
   graphqlTag: 'default',
+  watchModeBuffer: 150
 }
 
 const stateCache: {[key: string]: any} = {}
@@ -338,7 +340,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
           }
         }),
         map((event) => event.documentId),
-        bufferTime(100),
+        bufferTime(config.watchModeBuffer),
         map((ids) => uniq(ids)),
         filter((ids) => ids.length > 0),
         tap((updateIds) =>


### PR DESCRIPTION
Customization for large projects that change often to the point of breaking watch mode. With `watchModeBuffer` these users can specify higher values to batch node updates and prevent breaks.

Closes #135 