### PR TITLE
refactor(watchMode): wait on Gatsby's internals before node updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Explore http://localhost:8000/\_\_\_graphql after running `gatsby develop` to un
 | graphqlTag    | string  | `default` | If the Sanity GraphQL API was deployed using `--tag <name>`, use this to specify the tag name.                                                                     |
 | overlayDrafts | boolean | `false`   | Set to `true` in order for drafts to replace their published version. By default, drafts will be skipped.                                                          |
 | watchMode     | boolean | `false`   | Set to `true` to keep a listener open and update with the latest changes in realtime. If you add a `token` you will get all content updates down to each keypress. |
+| watchModeBuffer     | number | `150`   | How many milliseconds to wait on watchMode changes before applying them to Gatsby's GraphQL layer. Introduced in 7.2.0. |
 
 ## Preview of unpublished content
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Explore http://localhost:8000/\_\_\_graphql after running `gatsby develop` to un
 | graphqlTag    | string  | `default` | If the Sanity GraphQL API was deployed using `--tag <name>`, use this to specify the tag name.                                                                     |
 | overlayDrafts | boolean | `false`   | Set to `true` in order for drafts to replace their published version. By default, drafts will be skipped.                                                          |
 | watchMode     | boolean | `false`   | Set to `true` to keep a listener open and update with the latest changes in realtime. If you add a `token` you will get all content updates down to each keypress. |
-| watchModeBuffer     | number | `150`   | How many milliseconds to wait on watchMode changes before applying them to Gatsby's GraphQL layer. Introduced in 7.2.0. |
 
 ## Preview of unpublished content
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-sanity",
   "description": "Gatsby source plugin for building websites using Sanity.io as a backend.",
-  "version": "7.2.1-next.0",
+  "version": "7.2.1-next.1",
   "author": "Sanity.io <hello@sanity.io>",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-sanity",
   "description": "Gatsby source plugin for building websites using Sanity.io as a backend.",
-  "version": "7.2.1",
+  "version": "7.2.1-next.0",
   "author": "Sanity.io <hello@sanity.io>",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-sanity",
   "description": "Gatsby source plugin for building websites using Sanity.io as a backend.",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "author": "Sanity.io <hello@sanity.io>",
   "contributors": [
     {

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -67,6 +67,7 @@ const defaultConfig = {
   version: '1',
   overlayDrafts: false,
   graphqlTag: 'default',
+  watchModeBuffer: 150,
 }
 
 const stateCache: {[key: string]: any} = {}
@@ -349,13 +350,13 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
           }
         }),
         map((event) => event.documentId),
-        // Wait 50ms since the last internal change from Gatsby to let it rest before we add the nodes to GraphQL
+        // Wait `x`ms since the last internal change from Gatsby to let it rest before we add the nodes to GraphQL
         bufferWhen(() =>
           merge(
             gatsbyEvents,
             // If no Gatsby event, emit a dummy event just to unlock bufferWhen
             of(0),
-          ).pipe(debounceTime(50)),
+          ).pipe(debounceTime(config.watchModeBuffer)),
         ),
         filter((ids) => ids.length > 0),
         map((ids) => uniq(ids)),


### PR DESCRIPTION
Tries to fix Gatsby panicking when we update too many nodes non-stop (see error message below). Instead of relying on a fixed `bufferTime` to batch updates, we're now waiting until Gatsby's internals are quiet to run updates.

```
Panicking because nodes appear to be being changed every time we run queries.
This would cause the site to recompile infinitely.
Check custom resolvers to see if they are unconditionally creating or mutating
nodes on every query.
This may happen if they create nodes with a field that is different every time,
such as a timestamp or unique id.
```