### PR TITLE
fix: don't add gatsby internals to resolved reference gatsby nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes will be documented in this file.
 
+## 7.3.3
+
+### Fixes
+
+- Prevent the `resolveReferences` gatsby function's `remapRawFields` call from attaching `Internal` object to the resolved gatsby node, fixing Gatsby Cloud incremental build issues.
+
 ## 7.3.2
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-sanity",
   "description": "Gatsby source plugin for building websites using Sanity.io as a backend.",
-  "version": "7.3.2",
+  "version": "7.3.3",
   "author": "Sanity.io <hello@sanity.io>",
   "contributors": [
     {

--- a/src/util/resolveReferences.ts
+++ b/src/util/resolveReferences.ts
@@ -77,6 +77,7 @@ export function resolveReferences(
 function remapRawFields(obj: {[key: string]: any}) {
   const initial: {[key: string]: any} = {}
   return Object.keys(obj).reduce((acc, key) => {
+    if (key === "internal") { return acc }
     if (key.startsWith('_rawData')) {
       let targetKey = key.slice(8)
 


### PR DESCRIPTION
This PR resolves issues which occurs for Incremental Builds in Gatsby, when using the plugin.

The way that the Incremental Builds feature works is that it marks routes (HTML files + JSON page data) for regeneration if any of the following inputs change: https://www.gatsbyjs.com/docs/debugging-incremental-builds/#how-does-it-work

Our team experienced an issue where files were getting marked for regeneration on every build, even with no frontend code changing, or updates in the CMS.

The result of diffing between builds showed that the `page-data/*.json` files being outputted by the gatsby build had a changing value for the `counter` property in the `internal` object, sourced by the `gatsby-source-sanity` plugin: 
![image](https://user-images.githubusercontent.com/16191797/156286212-32142775-3a6a-4100-88e3-e3c032f40327.png)

This is a bug, since the counter result is changed between builds and these internals don't need to be exposed for node creation - they are used by Gatsby internally for tracking performance, and tests etc.

This small commit simply filters out those internals from getting added to the node to prevent the `counter` value changing to cause the pages to be marked for rebuild.
 
[Here's](https://www.typescriptlang.org/play?#code/GYVwdgxgLglg9mABAJwKYFsCGAHASpgdwDEZUAbAEwGcAKOAIwCsAuRAb0QG0BrVAT1ZUoyGGADmAXVaYwfRAF8AlOwBQiRBARDEomLExlWHHv0HDRk6bIWIAvO3lqUqKCGRIA8k1TQAdLz5aBkZFXzQKEAhUGhpMCAgAGkQA5VsAPlV1dRhgRBoAu1t7ACJRKFR3A2LlNFd3RDiIAG4nbNz8-l8hTGQoKgB1PQALGmKAfWRCABFMKExq5TZWrLIXRDnkMRcAaX47ZM6qMhgomgAORRVl9QB6G8QAGTg4bkRgOGREAFVsbAqAYUwVFQiAAbj0YDIoG8YMghEkcogwHBoe9wBQksI5BBMOhyIDgdd1j0tlBdnJ7FA+H84LlgpwNqTyRJCiV0ahgKJUBRiogAPzEzY7ficAAMEl8UDgTwIAKB0WUAGpBUzDsdTgBGZSsRnCvhXLJZRoMkl6ln2ekBCTLeSIcjAnTtACExqtiyJrv45sQlq9NuWtTcSEaTnkCLAekhZEujhUq2hyIoIPsS3UYxgFFYAHJsJgtgBJMDdMSTdBZhJOMZUv7Z3MFotzEu48uVtCg7MAKW4AFECABZAgAdjgAEEAIoAISmD3+AC18wBWdC4BcwDsttMQNCzbkjqDZgBMooPGoAtKKzueACwAFVFV+YooXzAAzKLZxvEGMQNgKDuKHuh7HmeF6ngeACcN4HgezAai+sGDh+FbqJoYDlGhrCcMsqaGl+ATZsAg7xFeg5PqgqAAGwLsAmALgeqAnleqCDuBHKoJg9BnAeV4ap+hpVtSqDZvQZBwBA3B8VkEBDDAlBoGAmEjsgkx8BIyG4VgyDcFMHJUIpymYKp6mGkIfCrNmyLIFgZBZjaxmZLhYz4YgWZwRAFD0BAg6oBqEAasAklptWQkuSJYkSfZKEyXJqAKVwSkqWpRKadpumYUluGIKZ5kuZZ1m2YajjqBl6x6DlWYAMpDHA2CIIWxalp+biGC5NyiA1zbqRM0yzJg-wIOh+5cNhRJOaYLmEcRpELuRVE0XRDEakxLFsRxXE8YFX7BcJoniZt0myRQ8n6YlkWIClOnAHp8UGUZRLZSFWZ5QYBVZGGI2ZWNAguW5HleT5fkBWdAk1qFu0RUSB0xXFnAJYZJWGhdaVcAjWQPRZHz5f6xVdZMBAzHMfYuJgf5zKw7KcmA3LqRm2anpgHEUAewCiuBp7cguL6nguC5JqerH0BRp4s1eopPmcosLhqFCflDR2xelNNoRUYAGEYyzbS5FUyHofAAAp5qg9WNo19moYNUwwFsQjZleL4vhRFCEbRg4URqZwUURV4LvQ4FnOB4ELq7GoLhRFHABAklwAQVPINmYizFQ9B8KeVBwG4USpzrVKSZo4DlHHiB2y+obqbm8lDWAIBkGQKixioqFp6sviiWINBoFgeCECQ5DUDQiaoIoihAA) a TS REPL demoing that the property gets dropped as expected with the change introduced in this commit