### PR TITLE
fix: helps incremental builds of large datasets by paginating

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -278,7 +278,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
       // Let's make sure we keep documents nodes already in the cache (3 steps)
       // =========
       // 1/4. Get all valid document IDs from Sanity
-      const documentIds = new Set((await getDocumentIds(client)).map(unprefixId))
+      const documentIds = new Set(await getDocumentIds(client))
 
       // 2/4. Get all document types implemented in the GraphQL layer
       // @initializePlugin() will populate `stateCache` with 1+ TypeMaps
@@ -308,7 +308,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
             if (
               node.internal.owner === 'gatsby-source-sanity' &&
               typeof node._id === 'string' &&
-              documentIds.has(unprefixId(node._id))
+              (documentIds.has(node._id) || documentIds.has(unprefixId(node._id)))
             ) {
               actions.touchNode(node)
               gatsbyNodes.set(unprefixId(node._id), node)

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -191,7 +191,8 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
 }
 
 const getDocumentIds = async (client: SanityClient): Promise<string[]> => {
-  const batchSize = 1000
+  // Largish batch size to reduce network round trips without putting too much stress on API
+  const batchSize = 30000
 
   let prevId: string | undefined
   let ids = [] as string[]

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -206,10 +206,10 @@ const getDocumentIds = async (client: SanityClient): Promise<string[]> => {
         batchSize,
       },
     )
-    if (batch.length === 0) {
+    ids.push(...batch)
+    if (batch.length < batchSize) {
       break
     }
-    ids = ids.concat(batch)
     prevId = batch[batch.length - 1]
   }
 


### PR DESCRIPTION
Helps incremental builds of large datasets by paginating fetching of document IDs, and optimizing their lookups using a set. Fixes #149.