### PR TITLE
docs/update-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Get up and running in minutes with a fully configured starter project:
 From the command line, use npm (node package manager) to install the plugin:
 
 ```console
-npm install gatsby-source-sanity
+npm install gatsby-source-sanity gatsby-plugin-image
 ```
 
-⚠️ Warning: if using Gatsby v4, make sure you've installed version 7.1.0 or higher.
+⚠️ Warning: if using Gatsby v4, make sure you've installed version 7.1.0 or higher. `gatsby-plugin-image` has it's own dependancies. Check the [Gatsby documentation](https://www.gatsbyjs.com/plugins/gatsby-plugin-image/#installation) for installation instructions. 
 
 In the `gatsby-config.js` file in the Gatsby project's root directory, add the plugin configuration inside of the `plugins` section:
 
@@ -45,6 +45,7 @@ In the `gatsby-config.js` file in the Gatsby project's root directory, add the p
 module.exports = {
   // ...
   plugins: [
+    `gatsby-plugin-image`,
     {
       resolve: `gatsby-source-sanity`,
       options: {


### PR DESCRIPTION
- add `gatsby-plugin-image` install notes.

Hi team, i'm not sure if it's worth adding further notes regarding `gatsby-plugin-image`. The Gatsby docs explain in full which dependaices are required depending on usage. This PR is just to advise folks to at least install `gatsby-plugin-image` or they'll see errors when attempting to run the Gatsby development server.

Happy to make any/all changes requrest.

Thanks in advance

Paul