### PR TITLE
fix(deps): Revert axios v1 bump in #185

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sanity/image-url": "^1.0.1",
         "@sanity/mutator": "^2.33.2",
         "@types/url-parse": "^1.4.8",
-        "axios": "^1.1.3",
+        "axios": "^0.27.2",
         "debug": "^4.3.4",
         "gatsby-core-utils": "^4.1.0",
         "gatsby-plugin-utils": "^4.1.0",
@@ -5999,13 +5999,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
-      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/axobject-query": {
@@ -19305,11 +19304,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@sanity/image-url": "^1.0.1",
     "@sanity/mutator": "^2.33.2",
     "@types/url-parse": "^1.4.8",
-    "axios": "^1.1.3",
+    "axios": "^0.27.2",
     "debug": "^4.3.4",
     "gatsby-core-utils": "^4.1.0",
     "gatsby-plugin-utils": "^4.1.0",


### PR DESCRIPTION
One of the changes that were merged between `gatsby-source-sanity` 7.5.1 and 7.6.0 is a major version bump for axios (v0 to v1) in https://github.com/sanity-io/gatsby-source-sanity/pull/185.

Was able to reproduce the behavior shown in https://github.com/sanity-io/gatsby-source-sanity/issues/200 via https://github.com/taulal/gatsby-source-sanity-bug-repo and fix it by [adding a resolution that pins axios to v0 again](https://github.com/tyhopp/gatsby-source-sanity-bug-repo/commit/4dbe7b718d931bca7865e7617858f5b73df4da03#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

Briefly looked for some direction from axios about what would need to change in [`getDocumentStream`](https://github.com/sanity-io/gatsby-source-sanity/blob/main/src/util/getDocumentStream.ts) to make it work with the new axios major, but the [renovate bot diff](https://app.renovatebot.com/package-diff?name=axios&from=0.27.2&to=1.1.3) covers too much ground and [there is no migration guide yet](https://github.com/axios/axios/discussions/4996).

For now then reverting and releasing a patch might be the best way to go about it.

I didn't find any tests that would cover this case, so please point me in that direction if I should add any. Otherwise running https://github.com/tyhopp/gatsby-source-sanity-bug-repo locally could work to verify the fix.

Fixes https://github.com/sanity-io/gatsby-source-sanity/issues/200