### PR TITLE
fix: getDocumentIds pagination query if custom _id values are used

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -201,8 +201,8 @@ const getDocumentIds = async (client: SanityClient): Promise<string[]> => {
   while (true) {
     const batch = await client.fetch<string[]>(
       prevId !== undefined
-        ? `*[!(_type match "system.**") && _id > $prevId][0...$batchSize]._id`
-        : `*[!(_type match "system.**")][0...$batchSize]._id`,
+        ? `*[!(_type match "system.**") && _id > $prevId]|order(_id asc)[0...$batchSize]._id`
+        : `*[!(_type match "system.**")]|order(_id asc)[0...$batchSize]._id`,
       {
         prevId: prevId || null,
         batchSize,


### PR DESCRIPTION
In order to perform a correct pagination base on `_id > $prevId`, all the ids should be ordered.
With this patch the order is enforced 