### PR TITLE
feat: use `@link` directive instead of custom resolvers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 public
 .vercel
 .vscode
+.DS_Store


### PR DESCRIPTION
We would like to add Sanity support to Netlify Connect, but the requirements for schemas are stricter than for Gatsby. This PR changes the schema to use `@link` directives instead of custom resolvers. As well as supporting Netlify Connect, having a stricter schema allows Gatsby to use performance optimisations that aren't possible with custom resolvers. As well as switching reference resolvers to `@link`, this changes union resolvers to instead add `internal.type` values to union fields. Doing this means we can remove all of the custom resolvers, apart from those used for raw fields.

