### PR TITLE
feat: add support for type prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Get up and running in minutes with a fully configured starter project:
 - [Generating pages](#generating-pages)
 - ["Raw" fields](#raw-fields)
 - [Portable Text / Block Content](#portable-text--block-content)
+- [Using multiple datasets](#using-multiple-datasets)
 - [Real-time content preview with watch mode](#real-time-content-preview-with-watch-mode)
 - [Updating content for editors with preview servers](#updating-content-for-editors-with-preview-servers)
 - [Using .env variables](#using-env-variables)
@@ -81,15 +82,16 @@ Explore `http://localhost:8000/___graphql` after running `gatsby develop` to und
 
 ## Options
 
-| Options         | Type    | Default   | Description                                                                                                                                                         |
-| --------------- | ------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| projectId       | string  |           | **[required]** Your Sanity project's ID                                                                                                                             |
-| dataset         | string  |           | **[required]** The dataset to fetch from                                                                                                                            |
-| token           | string  |           | Authentication token for fetching data from private datasets, or when using `overlayDrafts` [Learn more](https://www.sanity.io/docs/http-auth)                      |
-| graphqlTag      | string  | `default` | If the Sanity GraphQL API was deployed using `--tag <name>`, use this to specify the tag name.                                                                      |
-| overlayDrafts   | boolean | `false`   | Set to `true` in order for drafts to replace their published version. By default, drafts will be skipped.                                                           |
-| watchMode       | boolean | `false`   | Set to `true` to keep a listener open and update with the latest changes in realtime. If you add a `token` you will get all content updates down to each key press. |
-| watchModeBuffer | number  | `150`     | How many milliseconds to wait on watchMode changes before applying them to Gatsby's GraphQL layer. Introduced in 7.2.0.                                             |
+| Options         | Type    | Default   | Description                                                                                                                                                          |
+| --------------- | ------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| projectId       | string  |           | **[required]** Your Sanity project's ID                                                                                                                              |
+| dataset         | string  |           | **[required]** The dataset to fetch from                                                                                                                             |
+| token           | string  |           | Authentication token for fetching data from private datasets, or when using `overlayDrafts` [Learn more](https://www.sanity.io/docs/http-auth)                       |
+| graphqlTag      | string  | `default` | If the Sanity GraphQL API was deployed using `--tag <name>`, use this to specify the tag name.                                                                       |
+| overlayDrafts   | boolean | `false`   | Set to `true` in order for drafts to replace their published version. By default, drafts will be skipped.                                                            |
+| watchMode       | boolean | `false`   | Set to `true` to keep a listener open and update with the latest changes in realtime. If you add a `token` you will get all content updates down to each key press.  |
+| watchModeBuffer | number  | `150`     | How many milliseconds to wait on watchMode changes before applying them to Gatsby's GraphQL layer. Introduced in 7.2.0.                                              |
+| typePrefix      | string  |           | Prefix to use for the GraphQL types. This is prepended to `Sanity` in the type names and allows you to have multiple instances of the plugin in your Gatsby project. |
 
 ## Preview of unpublished content
 
@@ -243,6 +245,35 @@ Rich text in Sanity is usually represented as [Portable Text](https://www.portab
 These data structures can be deep and a chore to query (specifying all the possible fields). As [noted above](#raw-fields), there is a "raw" alternative available for these fields which is usually what you'll want to use.
 
 You can install [@portabletext/react](https://www.npmjs.com/package/@portabletext/react) from npm and use it in your Gatsby project to serialize Portable Text. It lets you use your own React components to override defaults and render custom content types. [Learn more about Portable Text in our documentation](https://www.sanity.io/docs/content-studio/what-you-need-to-know-about-block-text).
+
+## Using multiple datasets
+
+If you want to use more than one dataset in your site, you can do so by adding multiple instances of the plugin to your `gatsby-config.js` file. To avoid conflicting type names you can use the `typeName` option to set a custom prefix for the GraphQL types. These can be datasets from different projects, or different datasets within the same project.
+
+```js
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-source-sanity',
+      options: {
+        projectId: 'abc123',
+        dataset: 'production',
+      },
+    },
+    {
+      resolve: 'gatsby-source-sanity',
+      options: {
+        projectId: 'abc123',
+        dataset: 'staging',
+        typePrefix: 'Staging',
+      },
+    },
+  ],
+}
+```
+
+In this case, the type names for the first instance will be `Sanity<typeName>`, while the second will be `StagingSanity<typeName>`.
 
 ## Real-time content preview with watch mode
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -43,6 +43,7 @@ import {
 } from './util/remoteGraphQLSchema'
 import {rewriteGraphQLSchema} from './util/rewriteGraphQLSchema'
 import validateConfig, {PluginConfig} from './util/validateConfig'
+import {ProcessingOptions} from './util/normalize'
 
 let coreSupportsOnPluginInit: 'unstable' | 'stable' | undefined
 
@@ -101,7 +102,7 @@ const initializePlugin = async (
     stateCache[graphqlSdlKey] = graphqlSdl
 
     reporter.info('[sanity] Stitching GraphQL schemas from SDL')
-    const typeMap = getTypeMapFromGraphQLSchema(api)
+    const typeMap = getTypeMapFromGraphQLSchema(api, config.typePrefix)
     const typeMapKey = getCacheKey(config, CACHE_KEYS.TYPE_MAP)
     stateCache[typeMapKey] = typeMap
   } catch (err: any) {
@@ -233,7 +234,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   const url = client.getUrl(`/data/export/${dataset}?tag=sanity.gatsby.source-nodes`)
 
   // Stitches together required methods from within the context and actions objects
-  const processingOptions = {
+  const processingOptions: ProcessingOptions = {
     typeMap,
     createNodeId,
     createNode,
@@ -241,6 +242,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     createParentChildLink,
     overlayDrafts,
     client,
+    typePrefix: config.typePrefix,
   }
 
   // PREVIEW UPDATES THROUGH WEBHOOKS

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -11,5 +11,5 @@ export enum CACHE_KEYS {
 }
 
 export function getCacheKey(config: PluginConfig, suffix: CACHE_KEYS) {
-  return `${config.projectId}-${config.dataset}-${suffix}`
+  return `${config.projectId}-${config.dataset}-${config.typePrefix ?? ''}-${suffix}`
 }

--- a/src/util/getSyncWithGatsby.ts
+++ b/src/util/getSyncWithGatsby.ts
@@ -20,7 +20,7 @@ export default function getSyncWithGatsby(props: {
   args: SourceNodesArgs
 }): SyncWithGatsby {
   const {documents, gatsbyNodes, processingOptions, args} = props
-  const {typeMap, overlayDrafts} = processingOptions
+  const {typeMap, overlayDrafts, typePrefix} = processingOptions
   const {reporter, actions} = args
   const {createNode, deleteNode} = actions
 
@@ -38,7 +38,7 @@ export default function getSyncWithGatsby(props: {
 
     const doc = draft || published
     if (doc) {
-      const type = getTypeName(doc._type)
+      const type = getTypeName(doc._type, typePrefix)
       if (!typeMap.objects[type]) {
         reporter.warn(
           `[sanity] Document "${doc._id}" has type ${doc._type} (${type}), which is not declared in the GraphQL schema. Make sure you run "graphql deploy". Skipping document.`,

--- a/src/util/normalize.ts
+++ b/src/util/normalize.ts
@@ -12,9 +12,6 @@ import {SanityClient} from '@sanity/client'
 
 const scalarTypeNames = specifiedScalarTypes.map((def) => def.name).concat(['JSON', 'Date'])
 
-// Movie => SanityMovie
-const typePrefix = 'Sanity'
-
 // Node fields used internally by Gatsby.
 export const RESTRICTED_NODE_FIELDS = ['id', 'children', 'parent', 'fields', 'internal']
 
@@ -26,6 +23,7 @@ export interface ProcessingOptions {
   createParentChildLink: Actions['createParentChildLink']
   overlayDrafts: boolean
   client: SanityClient
+  typePrefix?: string
 }
 
 // Transform a Sanity document into a Gatsby node
@@ -33,12 +31,12 @@ export function toGatsbyNode(doc: SanityDocument, options: ProcessingOptions): S
   const {createNodeId, createContentDigest, overlayDrafts} = options
 
   const rawAliases = getRawAliases(doc, options)
-  const safe = prefixConflictingKeys(doc)
+  const safe = prefixConflictingKeys(doc, options.typePrefix)
   const withRefs = rewriteNodeReferences(safe, options)
 
   addInternalTypesToUnionFields(withRefs, options)
 
-  const type = getTypeName(doc._type)
+  const type = getTypeName(doc._type, options.typePrefix)
   const urlBuilder = imageUrlBuilder(options.client)
 
   const gatsbyImageCdnFields = [`SanityImageAsset`, `SanityFileAsset`].includes(type)
@@ -79,7 +77,7 @@ export function toGatsbyNode(doc: SanityDocument, options: ProcessingOptions): S
 // movie => SanityMovie
 // blog_post => SanityBlogPost
 // sanity.imageAsset => SanityImageAsset
-export function getTypeName(type: string) {
+export function getTypeName(type: string, typePrefix: string | undefined) {
   if (!type) {
     return type
   }
@@ -89,23 +87,23 @@ export function getTypeName(type: string) {
     return typeName
   }
 
-  return `${typePrefix}${typeName.replace(/\s+/g, '').replace(/^Sanity/, '')}`
+  return `${typePrefix ?? ''}Sanity${typeName.replace(/\s+/g, '').replace(/^Sanity/, '')}`
 }
 
 // {foo: 'bar', children: []} => {foo: 'bar', sanityChildren: []}
-function prefixConflictingKeys(obj: SanityDocument) {
+function prefixConflictingKeys(obj: SanityDocument, typePrefix: string | undefined) {
   // Will be overwritten, but initialize for type safety
   const initial: SanityDocument = {_id: '', _type: '', _rev: '', _createdAt: '', _updatedAt: ''}
 
   return Object.keys(obj).reduce((target, key) => {
-    const targetKey = getConflictFreeFieldName(key)
+    const targetKey = getConflictFreeFieldName(key, typePrefix)
     target[targetKey] = obj[key]
 
     return target
   }, initial)
 }
 
-export function getConflictFreeFieldName(fieldName: string) {
+export function getConflictFreeFieldName(fieldName: string, typePrefix: string | undefined) {
   return RESTRICTED_NODE_FIELDS.includes(fieldName)
     ? `${camelCase(typePrefix)}${upperFirst(fieldName)}`
     : fieldName
@@ -113,7 +111,7 @@ export function getConflictFreeFieldName(fieldName: string) {
 
 function getRawAliases(doc: SanityDocument, options: ProcessingOptions) {
   const {typeMap} = options
-  const typeName = getTypeName(doc._type)
+  const typeName = getTypeName(doc._type, options.typePrefix)
   const type = typeMap.objects[typeName]
   if (!type) {
     return {}
@@ -158,7 +156,7 @@ function addInternalTypesToUnionFields(doc: SanityDocument, options: ProcessingO
   const {typeMap} = options
   const types = extractWithPath('..[_type]', doc)
 
-  const typeName = getTypeName(doc._type)
+  const typeName = getTypeName(doc._type, options.typePrefix)
   const thisType = typeMap.objects[typeName]
   if (!thisType) {
     return
@@ -178,7 +176,7 @@ function addInternalTypesToUnionFields(doc: SanityDocument, options: ProcessingO
 
     const parentNode =
       type.path.length === parentOffset ? doc : get(doc, type.path.slice(0, -parentOffset))
-    const parentTypeName = getTypeName(parentNode._type)
+    const parentTypeName = getTypeName(parentNode._type, options.typePrefix)
     const parentType = typeMap.objects[parentTypeName]
 
     if (!parentType) {
@@ -191,13 +189,13 @@ function addInternalTypesToUnionFields(doc: SanityDocument, options: ProcessingO
       continue
     }
 
-    const fieldTypeName = getTypeName(field.namedType.name.value)
+    const fieldTypeName = getTypeName(field.namedType.name.value, options.typePrefix)
 
     // All this was just to check if we're dealing with a union field
     if (!typeMap.unions[fieldTypeName]) {
       continue
     }
-    const typeName = getTypeName(type.value)
+    const typeName = getTypeName(type.value, options.typePrefix)
 
     // Add the internal type to the field
     set(doc, type.path.slice(0, -1).concat('internal'), {type: typeName})

--- a/src/util/normalize.ts
+++ b/src/util/normalize.ts
@@ -87,7 +87,10 @@ export function getTypeName(type: string, typePrefix: string | undefined) {
     return typeName
   }
 
-  return `${typePrefix ?? ''}Sanity${typeName.replace(/\s+/g, '').replace(/^Sanity/, '')}`
+  const sanitized = typeName.replace(/\s+/g, '')
+
+  const prefix = `${typePrefix ?? ''}${sanitized.startsWith('Sanity') ? '' : 'Sanity'}`
+  return sanitized.startsWith(prefix) ? sanitized : `${prefix}${sanitized}`
 }
 
 // {foo: 'bar', children: []} => {foo: 'bar', sanityChildren: []}

--- a/src/util/remoteGraphQLSchema.ts
+++ b/src/util/remoteGraphQLSchema.ts
@@ -78,7 +78,7 @@ export async function getRemoteGraphQLSchema(client: SanityClient, config: Plugi
   }
 }
 
-export function getTypeMapFromGraphQLSchema(sdl: string): TypeMap {
+export function getTypeMapFromGraphQLSchema(sdl: string, typePrefix: string | undefined): TypeMap {
   const typeMap: TypeMap = {objects: {}, scalars: [], unions: {}}
   const remoteSchema = parse(sdl)
   const groups = {
@@ -100,7 +100,7 @@ export function getTypeMapFromGraphQLSchema(sdl: string): TypeMap {
       return acc
     }
 
-    const name = getTypeName(typeDef.name.value)
+    const name = getTypeName(typeDef.name.value, typePrefix)
     acc[name] = {
       name,
       kind: 'Object',
@@ -158,10 +158,10 @@ export function getTypeMapFromGraphQLSchema(sdl: string): TypeMap {
 
   const unions: {[key: string]: UnionTypeDef} = {}
   typeMap.unions = groups.UnionTypeDefinition.reduce((acc, typeDef: UnionTypeDefinitionNode) => {
-    const name = getTypeName(typeDef.name.value)
+    const name = getTypeName(typeDef.name.value, typePrefix)
     acc[name] = {
       name,
-      types: (typeDef.types || []).map((type) => getTypeName(type.name.value)),
+      types: (typeDef.types || []).map((type) => getTypeName(type.name.value, typePrefix)),
     }
     return acc
   }, unions)

--- a/src/util/rewriteGraphQLSchema.ts
+++ b/src/util/rewriteGraphQLSchema.ts
@@ -313,7 +313,7 @@ function maybeRewriteFieldName(
   }
 
   const parentTypeName = parent.name.value
-  const newFieldName = getConflictFreeFieldName(field.name.value)
+  const newFieldName = getConflictFreeFieldName(field.name.value, context.config.typePrefix)
 
   context.reporter.warn(
     `[sanity] Type \`${parentTypeName}\` has field with name \`${field.name.value}\`, which conflicts with Gatsby's internal properties. Renaming to \`${newFieldName}\``,

--- a/src/util/validateConfig.ts
+++ b/src/util/validateConfig.ts
@@ -11,6 +11,7 @@ export interface PluginConfig extends PluginOptions {
   overlayDrafts?: boolean
   watchMode?: boolean
   watchModeBuffer?: number
+  typePrefix?: string
 }
 
 export default function validateConfig(


### PR DESCRIPTION
This PR adds support for setting a custom type prefix, which allows multiple instances of the plugin to be used. The prefix is in addition to the `Sanity` prefix, so for example if you have a `movies` type, setting the type prefix to `Staging` will make the type `StagingSanityMovies`.