### PR TITLE
fix: use resolver for lists

### DIFF
--- a/src/util/getGraphQLResolverMap.ts
+++ b/src/util/getGraphQLResolverMap.ts
@@ -32,11 +32,13 @@ export function getGraphQLResolverMap(
     const objectType = typeMap.objects[typeName]
     const fieldNames = Object.keys(objectType.fields)
 
-    // Add resolvers for unions
+    // Add resolvers for unions and lists
     resolvers[objectType.name] = fieldNames
       .map((fieldName) => ({fieldName, ...objectType.fields[fieldName]}))
-      .filter((field) =>
-        isMixedUnion(getTypeName(field.namedType.name.value, pluginConfig.typePrefix), typeMap),
+      .filter(
+        (field) =>
+          field.isList ||
+          isMixedUnion(getTypeName(field.namedType.name.value, pluginConfig.typePrefix), typeMap),
       )
       .reduce((fields, field) => {
         const targetField = objectType.isDocument

--- a/src/util/getGraphQLResolverMap.ts
+++ b/src/util/getGraphQLResolverMap.ts
@@ -1,10 +1,26 @@
 import {camelCase} from 'lodash'
 import {CreateResolversArgs} from 'gatsby'
 import {GraphQLFieldResolver} from 'gatsby/graphql'
-import {GatsbyResolverMap, GatsbyGraphQLContext} from '../types/gatsby'
+import {GatsbyResolverMap, GatsbyGraphQLContext, GatsbyNodeModel} from '../types/gatsby'
 import {TypeMap, FieldDef} from './remoteGraphQLSchema'
 import {resolveReferences} from './resolveReferences'
 import {PluginConfig} from './validateConfig'
+import {getConflictFreeFieldName, getTypeName} from './normalize'
+import {SanityRef} from '../types/sanity'
+
+/**
+ * Is the type a union with both document and non-document types
+ */
+function isMixedUnion(typeName: string, typeMap: TypeMap) {
+  const union = typeMap.unions[typeName]
+  if (!union) {
+    return false
+  }
+  return (
+    union.types.some((typeName) => typeMap.objects[typeName]?.isDocument) &&
+    union.types.some((typeName) => !typeMap.objects[typeName]?.isDocument)
+  )
+}
 
 export function getGraphQLResolverMap(
   typeMap: TypeMap,
@@ -15,6 +31,21 @@ export function getGraphQLResolverMap(
   Object.keys(typeMap.objects).forEach((typeName) => {
     const objectType = typeMap.objects[typeName]
     const fieldNames = Object.keys(objectType.fields)
+
+    // Add resolvers for unions
+    resolvers[objectType.name] = fieldNames
+      .map((fieldName) => ({fieldName, ...objectType.fields[fieldName]}))
+      .filter((field) =>
+        isMixedUnion(getTypeName(field.namedType.name.value, pluginConfig.typePrefix), typeMap),
+      )
+      .reduce((fields, field) => {
+        const targetField = objectType.isDocument
+          ? getConflictFreeFieldName(field.fieldName, pluginConfig.typePrefix)
+          : field.fieldName
+
+        fields[targetField] = {resolve: getResolver(field, pluginConfig.typePrefix)}
+        return fields
+      }, resolvers[objectType.name] || {})
 
     // Add raw resolvers
     resolvers[objectType.name] = fieldNames
@@ -27,6 +58,39 @@ export function getGraphQLResolverMap(
   })
 
   return resolvers
+}
+
+function getResolver(
+  field: FieldDef & {fieldName: string},
+  typePrefix?: string,
+): GraphQLFieldResolver<{[key: string]: any}, GatsbyGraphQLContext> {
+  return (source, args, context) => {
+    if (field.isList) {
+      const items: SanityRef[] = source[field.fieldName] || []
+      return items && Array.isArray(items)
+        ? items.map((item) => maybeResolveReference(item, context.nodeModel, typePrefix))
+        : []
+    }
+
+    const item: SanityRef | undefined = source[field.fieldName]
+    return maybeResolveReference(item, context.nodeModel, typePrefix)
+  }
+}
+
+function maybeResolveReference(
+  item: {_ref?: string; _type?: string; internal?: {}} | undefined,
+  nodeModel: GatsbyNodeModel,
+  typePrefix?: string,
+) {
+  if (item && typeof item._ref === 'string') {
+    return nodeModel.getNodeById({id: item._ref})
+  }
+
+  if (item && typeof item._type === 'string' && !item.internal) {
+    return {...item, internal: {type: getTypeName(item._type, typePrefix)}}
+  }
+
+  return item
 }
 
 function getRawResolver(

--- a/src/util/getGraphQLResolverMap.ts
+++ b/src/util/getGraphQLResolverMap.ts
@@ -8,20 +8,6 @@ import {PluginConfig} from './validateConfig'
 import {getConflictFreeFieldName, getTypeName} from './normalize'
 import {SanityRef} from '../types/sanity'
 
-/**
- * Is the type a union with both document and non-document types
- */
-function isMixedUnion(typeName: string, typeMap: TypeMap) {
-  const union = typeMap.unions[typeName]
-  if (!union) {
-    return false
-  }
-  return (
-    union.types.some((typeName) => typeMap.objects[typeName]?.isDocument) &&
-    union.types.some((typeName) => !typeMap.objects[typeName]?.isDocument)
-  )
-}
-
 export function getGraphQLResolverMap(
   typeMap: TypeMap,
   pluginConfig: PluginConfig,
@@ -32,14 +18,10 @@ export function getGraphQLResolverMap(
     const objectType = typeMap.objects[typeName]
     const fieldNames = Object.keys(objectType.fields)
 
-    // Add resolvers for unions and lists
+    // Add resolvers for lists
     resolvers[objectType.name] = fieldNames
       .map((fieldName) => ({fieldName, ...objectType.fields[fieldName]}))
-      .filter(
-        (field) =>
-          field.isList ||
-          isMixedUnion(getTypeName(field.namedType.name.value, pluginConfig.typePrefix), typeMap),
-      )
+      .filter((field) => field.isList)
       .reduce((fields, field) => {
         const targetField = objectType.isDocument
           ? getConflictFreeFieldName(field.fieldName, pluginConfig.typePrefix)


### PR DESCRIPTION
PR #242 tried to improve efficiency of resolution by using Gatbsy's built-in `@link` directives rather than custom resolvers for all references. However it caused a regression (#245) in cases where there is a list type with a union that contains a mix of references and inline nodes. This isn't a pattern that can be represented in Gatsby by default, so the `@link` directive failed. Alongside this, lists of references don't have the `@reference` directive added in the Sanity schema, so there is no way to determine if they are inline or references. This meant we can't reliably add `@link` directives for these.

For thios reason, this PR adds back custom resolvers for lists.

I have tested this locally with many sorts of lists and it works well, but I would like to work out a way to add better tests to handle this.

Fixes #245