### PR TITLE
fix: only apply prefix once

### DIFF
--- a/packages/gatsby-source-sanity/src/util/normalize.ts
+++ b/packages/gatsby-source-sanity/src/util/normalize.ts
@@ -82,6 +82,10 @@ export function getTypeName(type: string, typePrefix: string | undefined) {
     return type
   }
 
+  if (typePrefix && type.startsWith(typePrefix)) {
+    return type
+  }
+
   const typeName = startCase(type)
   if (scalarTypeNames.includes(typeName)) {
     return typeName


### PR DESCRIPTION
Simple check that we do not add a configured prefix more than once, as was happening in certain situations
