### PR TITLE
fix: handle built in asset types when prefixing type names

### DIFF
--- a/examples/shared-content/gatsby-config.js
+++ b/examples/shared-content/gatsby-config.js
@@ -9,6 +9,7 @@ module.exports = {
       options: {
         projectId: 'jn1oq55b',
         dataset: 'production',
+        typePrefix: 'prod',
       },
       //typePrefix: 'prod',
     },
@@ -17,6 +18,7 @@ module.exports = {
       options: {
         projectId: 'jn1oq55b',
         dataset: 'shared',
+        typePrefix: 'shared',
       },
       //typePrefix: 'shared',
     },

--- a/examples/shared-content/src/pages/index.js
+++ b/examples/shared-content/src/pages/index.js
@@ -11,8 +11,17 @@ export default function Page({data}) {
         </div>
         <div className="relative mx-auto max-w-7xl">
           <div className="mx-auto mt-12 grid max-w-lg gap-5 lg:max-w-none lg:grid-cols-3">
-            {data.allSanityBook.edges.map(({node}) => (
+            {data.allProdSanityBook.edges.map(({node}) => (
               <div key={node._id} className="flex flex-col overflow-hidden rounded-lg shadow-lg">
+                <div className="flex-shrink-0">
+                  {node.cover ? (
+                    <GatsbyImage
+                      alt=""
+                      className="h-48 w-full object-cover"
+                      image={node.cover.asset.gatsbyImageData}
+                    />
+                  ) : null}
+                </div>
                 <div className="flex flex-1 flex-col justify-between bg-white p-6">
                   <div className="flex-1">
                     <a className="mt-2 block">
@@ -56,11 +65,16 @@ export const Head = () => <title>gatsby-source-sanity</title>
 
 export const query = graphql`
   query {
-    allSanityBook {
+    allProdSanityBook {
       edges {
         node {
           _id
           title
+          cover {
+            asset {
+              gatsbyImageData(fit: FILLMAX, placeholder: BLURRED)
+            }
+          }
         }
       }
     }

--- a/packages/gatsby-source-sanity/src/gatsby-node.ts
+++ b/packages/gatsby-source-sanity/src/gatsby-node.ts
@@ -42,7 +42,7 @@ import {
 } from './util/remoteGraphQLSchema'
 import {rewriteGraphQLSchema} from './util/rewriteGraphQLSchema'
 import validateConfig, {PluginConfig} from './util/validateConfig'
-import {ProcessingOptions} from './util/normalize'
+import {ProcessingOptions, getTypeName} from './util/normalize'
 import { mapCrossDatasetReferences } from './util/mapCrossDatasetReferences'
 
 let coreSupportsOnPluginInit: 'unstable' | 'stable' | undefined
@@ -191,7 +191,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
      */
     addRemoteFilePolyfillInterface(
       schema.buildObjectType({
-        name: `SanityImageAsset`,
+        name: getTypeName('SanityImageAsset', pluginConfig.typePrefix),
         fields: {},
         interfaces: [`Node`, `RemoteFile`],
       }),
@@ -432,8 +432,10 @@ export const setFieldsOnGraphQLNodeType: GatsbyNode['setFieldsOnGraphQLNodeType'
   pluginConfig: PluginConfig,
 ) => {
   const {type} = context
+  const {typePrefix} = pluginConfig
+  const sanityImageAssetTypeName = getTypeName('SanityImageAsset', typePrefix)
   let fields: {[key: string]: GraphQLFieldConfig<any, any>} = {}
-  if (type.name === 'SanityImageAsset') {
+  if (type.name === sanityImageAssetTypeName) {
     fields = {...fields, ...extendImageNode(pluginConfig)}
   }
 

--- a/packages/gatsby-source-sanity/src/util/normalize.ts
+++ b/packages/gatsby-source-sanity/src/util/normalize.ts
@@ -39,14 +39,14 @@ export function toGatsbyNode(doc: SanityDocument, options: ProcessingOptions): S
   const type = getTypeName(doc._type, options.typePrefix)
   const urlBuilder = imageUrlBuilder(options.client)
 
-  const gatsbyImageCdnFields = [`SanityImageAsset`, `SanityFileAsset`].includes(type)
+  const gatsbyImageCdnFields = [`sanity.imageAsset`, `sanity.fileAsset`].includes(doc._type)
     ? {
         filename: withRefs.originalFilename,
         width: withRefs?.metadata?.dimensions?.width,
         height: withRefs?.metadata?.dimensions?.height,
         url: withRefs?.url,
         placeholderUrl:
-          type === `SanityImageAsset`
+          doc._type === `sanity.imageAsset`
             ? urlBuilder
                 .image(withRefs.url)
                 .width(20)


### PR DESCRIPTION
When prefixing type names, certain code paths would not handle SanityImageAsset (and others) correctly. This PR ensures that we consider potential prefixing where we handle especially SanityImageAsset.
