### PR TITLE
fix handleDeltaChanges with correct lastBuildTime type

### DIFF
--- a/packages/gatsby-source-sanity/src/util/handleDeltaChanges.ts
+++ b/packages/gatsby-source-sanity/src/util/handleDeltaChanges.ts
@@ -24,7 +24,7 @@ export default async function handleDeltaChanges({
   config,
 }: {
   args: SourceNodesArgs
-  lastBuildTime: Date
+  lastBuildTime: string
   client: SanityClient
   syncWithGatsby: SyncWithGatsby
   config: PluginConfig
@@ -35,7 +35,7 @@ export default async function handleDeltaChanges({
     const changedDocs = await client.fetch<SanityDocument[]>(
       '*[!(_type match "system.**") && _updatedAt > $timestamp]',
       {
-        timestamp: lastBuildTime.toISOString(),
+        timestamp: lastBuildTime,
       },
     )
     changedDocs.forEach((doc) => {


### PR DESCRIPTION
### Description

The `lastBuildTime` variable was incorrectly typed as a `Date`, while it is actually a `string` returned by the cache system.
This caused a silent runtime error: `toISOString is not a function`
which resulted in the delta check always failing and all documents being re-synced.

This commit corrects the type and ensures proper handling of `lastBuildTime`.

### Testing

1. Run `gatsby develop` twice.
2. On the second run, verify that only changed documents are synced with Sanity.